### PR TITLE
Config.addSerialization() parameter type is too strict?

### DIFF
--- a/src/jvm/backtype/storm/Config.java
+++ b/src/jvm/backtype/storm/Config.java
@@ -343,7 +343,7 @@ public class Config extends HashMap<String, Object> {
         put(Config.TOPOLOGY_MESSAGE_TIMEOUT_SECS, secs);
     }
     
-    public void addSerialization(int token, Class<ISerialization> serialization) {
+    public void addSerialization(int token, Class<? extends ISerialization> serialization) {
         if(!containsKey(Config.TOPOLOGY_SERIALIZATIONS)) {
             put(Config.TOPOLOGY_SERIALIZATIONS, new HashMap());
         }


### PR DESCRIPTION
I'm trying to register a custom serializer using `config.addSerialization(33, SimpleJSONSerializer.class)`, but I can't get it to compile.  I get: "The method addSerialization(int, Class<ISerialization>) in the type Config is not applicable for the arguments (int, Class<SimpleJSONSerializer>)"

My memory of Java generics is pretty rusty, but I think it's because the type `Class<ISerialization>` is too strict, and the only value I can pass to it is `ISerialization.class` (which compiles, but obviously doesn't work).  I believe the intended parameter type is actually `Class<? extends ISerialization>`, which can be passed any `Foo.class` so long as `Foo implements ISerialization`.

If I fall back to

``` java
config.put(Config.TOPOLOGY_SERIALIZATIONS, Collections.singletonMap(33, "uk.co.samstokes.storm.serializer.SimpleJSONSerializer"));
```

then it works fine, so my serialiser is definitely working.
