### PR TITLE
fixed possible client config parsing issue

### DIFF
--- a/src/jvm/backtype/storm/utils/NimbusClient.java
+++ b/src/jvm/backtype/storm/utils/NimbusClient.java
@@ -2,6 +2,8 @@ package backtype.storm.utils;
 
 import backtype.storm.Config;
 import backtype.storm.generated.Nimbus;
+
+import java.util.List;
 import java.util.Map;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
@@ -12,7 +14,9 @@ import org.apache.thrift.transport.TTransport;
 
 public class NimbusClient {
     public static NimbusClient getConfiguredClient(Map conf) {
-        String nimbusHost = (String) conf.get(Config.NIMBUS_HOST);
+    	List<String> hosts = (List<String>) conf.get(Config.NIMBUS_HOST);
+        String nimbusHost = hosts.get(0); 
+        //TODO: may want to throw an error here if hosts.size() > 1
         int nimbusPort = ((Long) conf.get(Config.NIMBUS_THRIFT_PORT)).intValue();
         return new NimbusClient(nimbusHost, nimbusPort);
     }


### PR DESCRIPTION
was having some trouble getting "production" cluster running locally. I was getting an exception in NimbusClient.java. Looks like the YAML parser was giving back an ArrayList and we were casting it to a String. This fixes the issue, but given no one else has run into this I wonder if its because I was doing something else wrong.
