### PR TITLE
When developing in local mode when a task fails we don't want the whole process to halt

### DIFF
--- a/src/clj/backtype/storm/daemon/task.clj
+++ b/src/clj/backtype/storm/daemon/task.clj
@@ -185,8 +185,9 @@
                        (.report-task-error storm-cluster-state storm-id task-id error))
         
         report-error-and-die (fn [error]
-                                (report-error error)
-                                (halt-process! 1 "Task died"))
+                               (report-error error)
+                               (when (not= "local" (storm-conf STORM-CLUSTER-MODE))
+                                 (halt-process! 1 "Task died")))
 
         ;; heartbeat ASAP so nimbus doesn't reassign
         heartbeat-thread (async-loop

--- a/src/clj/backtype/storm/daemon/worker.clj
+++ b/src/clj/backtype/storm/daemon/worker.clj
@@ -169,7 +169,6 @@
                             (when @active (heartbeat-fn) (conf WORKER-HEARTBEAT-FREQUENCY-SECS))
                             )
                           :priority Thread/MAX_PRIORITY)        
-        tasks (dofor [tid task-ids] (task/mk-task conf storm-conf (mk-topology-context tid) storm-id mq-context cluster-state storm-active-atom transfer-fn))
         threads [(async-loop
                   (fn []
                     (.add event-manager refresh-connections)
@@ -194,6 +193,7 @@
                     0 )
                   :args-fn (fn [] [(ArrayList.) (TupleSerializer. storm-conf)]))
                  heartbeat-thread]
+        tasks (dofor [tid task-ids] (task/mk-task conf storm-conf (mk-topology-context tid) storm-id mq-context cluster-state storm-active-atom transfer-fn threads))
         virtual-port-shutdown (when (local-mode-zmq? conf)
                                 (log-message "Launching virtual port for " supervisor-id ":" port)
                                 (msg-loader/launch-virtual-port!


### PR DESCRIPTION
I attempted a small fix to this issue, with my addition the only difference is that the process doesn't halt instead it just fails (which works OK for me because i always shutdown a local-topology after some time, but i need to further patch this to shutdown automatically when an error is thrown).

Can you please provide assistance on how to shutdown everything from within task or within worker/mk-worker so i can pass it down to mk-tasks? I can retry the patch again.

I saw kill-local-storm-cluster in testing.clj but i don't seem to have for example a reference to nimbus.
