### PR TITLE
Adds storm.zookeeper.retry.times and storm.zookeeper.retry.interval 

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -9,6 +9,8 @@ storm.local.dir: "/mnt/storm"
 storm.zookeeper.port: 2181
 storm.zookeeper.root: "/storm"
 storm.zookeeper.session.timeout: 20000
+storm.zookeeper.retry.times: 5
+storm.zookeeper.retry.interval: 1000
 storm.cluster.mode: "distributed" # can be distributed or local
 storm.local.mode.zmq: false
 

--- a/src/clj/backtype/storm/cluster.clj
+++ b/src/clj/backtype/storm/cluster.clj
@@ -28,7 +28,9 @@
         active (atom true)
         mk-zk #(zk/mk-client (mk-zk-connect-string conf)
                              (conf STORM-ZOOKEEPER-SESSION-TIMEOUT)
-                             %)
+                             %
+                             (conf STORM-ZOOKEEPER-RETRY-TIMES)
+                             (conf STORM-ZOOKEEPER-RETRY-INTERVAL))
         zk (mk-zk (fn [state type path]
                     (when @active
                       (when-not (= :connected state)

--- a/src/clj/backtype/storm/zookeeper.clj
+++ b/src/clj/backtype/storm/zookeeper.clj
@@ -28,13 +28,12 @@
 
 
 (defn mk-client
-  ([conn-str session-timeout watcher]
+  ([conn-str session-timeout watcher retry-times retry-interval]
      (let [fk (CuratorFrameworkFactory/newClient
                conn-str
                session-timeout
                15000
-               ;;TODO: consider making this configurable
-               (RetryNTimes. 5 1000))]
+               (RetryNTimes. retry-times retry-interval))]
        (.. fk
            (getCuratorListenable)
            (addListener
@@ -54,6 +53,8 @@
                 (halt-process! 1 "Unrecoverable Zookeeper error")))))
        (.start fk)
        fk))
+  ([conn-str session-timeout watcher]
+       (mk-client conn-str 10000 watcher 5 1000))
   ([conn-str watcher]
      (mk-client conn-str 10000 watcher))
   ([conn-str]

--- a/src/jvm/backtype/storm/Config.java
+++ b/src/jvm/backtype/storm/Config.java
@@ -65,6 +65,16 @@ public class Config extends HashMap<String, Object> {
      * The timeout for clients to ZooKeeper.
      */
     public static String STORM_ZOOKEEPER_SESSION_TIMEOUT = "storm.zookeeper.session.timeout";
+    
+    /**
+     * The times for clients retry to operates with zookeeper
+     */
+    public static String STORM_ZOOKEEPER_RETRY_TIMES="storm.zookeeper.retry.times";
+    
+    /**
+     * The interval for clients retry to operates with zookeeper
+     */
+    public static String STORM_ZOOKEEPER_RETRY_INTERVAL="storm.zookeeper.retry.interval";
 
     /**
      * The id assigned to a running topology. The id is the storm name with a unique nonce appended.


### PR DESCRIPTION
This patch adds two new options for zookeeper:

```
storm.zookeeper.retry.times
storm.zookeeper.retry.interval 
```

They define zookeeper clients retry policy.Please check the difference.
