### PR TITLE
Update childopts for supervisor; add childopts for ui; bin/storm polish

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -111,7 +111,7 @@ def supervisor():
 
 def ui():
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    childopts = confvalue("ui.childopts", cpppaths) + " -Dlogfile.name=ui.log -Dlog4j.configuration=storm.log.properties"
+    childopts = confvalue("ui.childopts", cppaths) + " -Dlogfile.name=ui.log -Dlog4j.configuration=storm.log.properties"
     exec_storm_class("backtype.storm.ui.core", jvmtype="-server", childopts=childopts, extrajars=[STORM_DIR + "/log4j", STORM_DIR, STORM_DIR + "/conf"])
 
 def drpc():

--- a/bin/storm
+++ b/bin/storm
@@ -106,11 +106,12 @@ def nimbus():
 
 def supervisor():
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    childopts = confvalue("nimbus.childopts", cppaths) + " -Dlogfile.name=supervisor.log -Dlog4j.configuration=storm.log.properties"
+    childopts = confvalue("supervisor.childopts", cppaths) + " -Dlogfile.name=supervisor.log -Dlog4j.configuration=storm.log.properties"
     exec_storm_class("backtype.storm.daemon.supervisor", jvmtype="-server", extrajars=cppaths, childopts=childopts)
 
 def ui():
-    childopts = "-Xmx768m -Dlogfile.name=ui.log -Dlog4j.configuration=storm.log.properties"
+    cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
+    childopts = confvalue("ui.childopts", cpppaths) + " -Dlogfile.name=ui.log -Dlog4j.configuration=storm.log.properties"
     exec_storm_class("backtype.storm.ui.core", jvmtype="-server", childopts=childopts, extrajars=[STORM_DIR + "/log4j", STORM_DIR, STORM_DIR + "/conf"])
 
 def drpc():
@@ -119,11 +120,6 @@ def drpc():
 
 def print_classpath():
   print get_classpath([])
-
-COMMANDS = {"jar": jar, "kill": kill, "shell": shell, "nimbus": nimbus, "ui": ui,
-            "drpc": drpc, "supervisor": supervisor, "localconfvalue": print_localconfvalue,
-            "remoteconfvalue": print_remoteconfvalue, "repl": repl, "classpath": print_classpath,
-            "activate": activate, "deactivate": deactivate, "rebalance": rebalance}
 
 def print_commands():
     global COMMANDS
@@ -137,6 +133,11 @@ def print_usage(msg=None):
         print msg
     print_commands()
 
+COMMANDS = {"jar": jar, "kill": kill, "shell": shell, "nimbus": nimbus, "ui": ui,
+            "drpc": drpc, "supervisor": supervisor, "localconfvalue": print_localconfvalue,
+            "remoteconfvalue": print_remoteconfvalue, "repl": repl, "classpath": print_classpath,
+            "activate": activate, "deactivate": deactivate, "rebalance": rebalance, "help": print_usage}
+
 def main():
     if len(sys.argv) <= 1:
         print_usage()
@@ -144,7 +145,7 @@ def main():
 
     COMMAND = sys.argv[1]
     ARGS = sys.argv[2:]
-    COMMANDS[COMMAND](*ARGS)
+    (COMMANDS.get(COMMAND, "help"))(*ARGS)
     
 if __name__ == "__main__":
     main()

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -24,7 +24,9 @@ nimbus.task.launch.secs: 120
 nimbus.reassign: true
 nimbus.file.copy.expiration.secs: 600
 
+### ui.* configs are for the master
 ui.port: 8080
+ui.childopts: "-Xmx768m"
 
 drpc.port: 3772
 drpc.invocations.port: 3773


### PR DESCRIPTION
- Changed supervisor() to use supervisor.childopts (looks like just a copy/paste/nochange)
- Created a 'storm help' command that re-uses the existing print_usage
- Made unknown commands default to 'storm help' instead of stacktracing
- Added ui.childopts to ui(), to include JVM args to ui processes
- Added default -Xmx768m to ui.childopts entry in defaults.yaml, based on what had been in bin/storm
