### PR TITLE
Added check for null servers list on the setup of the DRPCSpout. Fixes #...

### DIFF
--- a/src/jvm/backtype/storm/drpc/DRPCSpout.java
+++ b/src/jvm/backtype/storm/drpc/DRPCSpout.java
@@ -63,7 +63,7 @@ public class DRPCSpout implements IRichSpout {
 
             int port = Utils.getInt(conf.get(Config.DRPC_INVOCATIONS_PORT));
             List<String> servers = (List<String>) conf.get(Config.DRPC_SERVERS);
-            if(servers.isEmpty()) {
+            if(servers == null || servers.isEmpty()) {
                 throw new RuntimeException("No DRPC servers configured for topology");   
             }
             if(numTasks < servers.size()) {


### PR DESCRIPTION
...112

Found this bug whilst I was testing out storm drpc for some projects I'm working on. This should make the error logged more clear if users don't add servers to the drpc list before they run a drpc topology.
