### PR TITLE
Added the lein eclipse plugin to the project.clj. You can generate eclip...

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,7 @@
   :dev-dependencies [
                      [swank-clojure "1.2.1"]
                      [lein-ring "0.4.5"]
+                     [lein-eclipse "1.0.0"]
                     ]
   :jvm-opts ["-Djava.library.path=/usr/local/lib:/opt/local/lib:/usr/lib"]
   :ring {:handler backtype.storm.ui.core/app}


### PR DESCRIPTION
...se .project and .classpath files by running lein eclipse.

I'm used to working in eclipse for projects (as I guess are quite a few Java developers) so it would be great if the lein-eclipse plugin could be added to make support for that easier.

Thanks,
