### PR TITLE
add storm home for default log4j configuration to use absolute path for logs folder

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -63,7 +63,7 @@ def print_remoteconfvalue(name):
 
 def exec_storm_class(klass, jvmtype="-server", childopts="", extrajars=[], args=[]):
     nativepath = confvalue("java.library.path", extrajars)
-    command = "java " + jvmtype + " -Djava.library.path=" + nativepath + " " + childopts + " -cp " + get_classpath(extrajars) + " " + klass + " " + " ".join(args)
+    command = "java " + jvmtype + " -Dstorm.home=" + STORM_DIR + " -Djava.library.path=" + nativepath + " " + childopts + " -cp " + get_classpath(extrajars) + " " + klass + " " + " ".join(args)
     print "Running: " + command    
     os.system(command)
 

--- a/log4j/storm.log.properties
+++ b/log4j/storm.log.properties
@@ -2,7 +2,7 @@ log4j.rootLogger=INFO, A1
 
 
 log4j.appender.A1 = org.apache.log4j.DailyRollingFileAppender
-log4j.appender.A1.File = logs/${logfile.name}
+log4j.appender.A1.File = ${storm.home}/logs/${logfile.name}
 log4j.appender.A1.Append = true
 log4j.appender.A1.DatePattern = '.'yyy-MM-dd
 log4j.appender.A1.layout = org.apache.log4j.PatternLayout


### PR DESCRIPTION
Use the storm.home env property to make the logs path absolute

With the default configuration , if start the storm not in the storm home folder, the logs will be written into the relative path of the working directory, which is hard to trace.
