### PR TITLE
ShellSpout, async ShellBolt, python implementation

### DIFF
--- a/src/clj/backtype/storm/clojure.clj
+++ b/src/clj/backtype/storm/clojure.clj
@@ -229,6 +229,7 @@
 (defalias bolt-spec thrift/mk-bolt-spec)
 (defalias spout-spec thrift/mk-spout-spec)
 (defalias shell-bolt-spec thrift/mk-shell-bolt-spec)
+(defalias shell-spout-spec thrift/mk-shell-spout-spec)
 
 (defn submit-remote-topology [name conf topology]
   (StormSubmitter/submitTopology name conf topology))

--- a/src/clj/backtype/storm/thrift.clj
+++ b/src/clj/backtype/storm/thrift.clj
@@ -157,13 +157,24 @@
     {:obj spout :p parallelism-hint :conf conf}
     ))
 
+(defn- shell-component-params [command script-or-output-spec kwargs]
+  (if (string? script-or-output-spec)
+    [(into-array String [command script-or-output-spec])
+     (first kwargs)
+     (rest kwargs)]
+    [(into-array String command)
+     script-or-output-spec
+     kwargs]))
+
 (defnk mk-bolt-spec [inputs bolt :parallelism-hint nil :p nil :conf nil]
   (let [parallelism-hint (if p p parallelism-hint)]
     {:obj bolt :inputs inputs :p parallelism-hint :conf conf}
     ))
 
-(defn mk-shell-bolt-spec [inputs command script output-spec & kwargs]
-  (apply mk-bolt-spec inputs (RichShellBolt. command script (mk-output-spec output-spec)) kwargs))
+(defn mk-shell-bolt-spec [inputs command script-or-output-spec & kwargs]
+  (let [[command output-spec kwargs]
+        (shell-component-params command script-or-output-spec kwargs)]
+    (apply mk-bolt-spec inputs (RichShellBolt. command (mk-output-spec output-spec)) kwargs)))
 
 (defn- add-inputs [declarer inputs]
   (doseq [[id grouping] (mk-inputs inputs)]

--- a/src/clj/backtype/storm/thrift.clj
+++ b/src/clj/backtype/storm/thrift.clj
@@ -7,7 +7,7 @@
   (:import [backtype.storm Constants])
   (:import [backtype.storm.grouping CustomStreamGrouping])
   (:import [backtype.storm.topology TopologyBuilder])
-  (:import [backtype.storm.clojure RichShellBolt])
+  (:import [backtype.storm.clojure RichShellBolt RichShellSpout])
   (:import [org.apache.thrift7.protocol TBinaryProtocol TProtocol])
   (:import [org.apache.thrift7.transport TTransport TFramedTransport TSocket])
   (:use [backtype.storm util config])
@@ -175,6 +175,11 @@
   (let [[command output-spec kwargs]
         (shell-component-params command script-or-output-spec kwargs)]
     (apply mk-bolt-spec inputs (RichShellBolt. command (mk-output-spec output-spec)) kwargs)))
+
+(defn mk-shell-spout-spec [command script-or-output-spec & kwargs]
+  (let [[command output-spec kwargs]
+        (shell-component-params command script-or-output-spec kwargs)]
+   (apply mk-spout-spec (RichShellSpout. command (mk-output-spec output-spec)) kwargs)))
 
 (defn- add-inputs [declarer inputs]
   (doseq [[id grouping] (mk-inputs inputs)]

--- a/src/dev/resources/tester.py
+++ b/src/dev/resources/tester.py
@@ -1,8 +1,0 @@
-import storm
-
-class TesterBolt(storm.Bolt):
-    def process(self, tup):
-        storm.emit([tup.values[0]+"lalala"])
-        storm.ack(tup)
-
-TesterBolt().run()

--- a/src/dev/resources/tester_bolt.py
+++ b/src/dev/resources/tester_bolt.py
@@ -1,0 +1,16 @@
+import storm
+from random import random
+
+class TesterBolt(storm.Bolt):
+    def initialize(self, conf, context):
+        storm.emit(['bolt initializing'])
+
+    def process(self, tup):
+        word = tup.values[0];
+        if (random() < 0.75):
+            storm.emit([word + 'lalala'], anchors=[tup])
+            storm.ack(tup)
+        else:
+            storm.log(word + ' randomly skipped!')
+
+TesterBolt().run()

--- a/src/dev/resources/tester_spout.py
+++ b/src/dev/resources/tester_spout.py
@@ -1,0 +1,26 @@
+from storm import Spout, emit, log
+from random import choice
+from time import sleep
+from uuid import uuid4
+
+words = ["nathan", "mike", "jackson", "golda", "bertels"]
+
+class TesterSpout(Spout):
+    def initialize(self, conf, context):
+        emit(['spout initializing'])
+        self.pending = {}
+
+    def nextTuple(self):
+        sleep(1.0/2)
+        word = choice(words)
+        id = str(uuid4())
+        self.pending[id] = word
+        emit([word], id=id)
+
+    def ack(self, id):
+        del self.pending[id]
+
+    def fail(self, id):
+        emit([self.pending[id]], id=id)
+
+TesterSpout().run()

--- a/src/jvm/backtype/storm/clojure/RichShellBolt.java
+++ b/src/jvm/backtype/storm/clojure/RichShellBolt.java
@@ -10,8 +10,8 @@ import java.util.Map;
 public class RichShellBolt extends ShellBolt implements IRichBolt {
     private Map<String, StreamInfo> _outputs;
     
-    public RichShellBolt(String script, String command, Map<String, StreamInfo> outputs) {
-        super(script, command);
+    public RichShellBolt(String[] command, Map<String, StreamInfo> outputs) {
+        super(command);
         _outputs = outputs;
     }
     

--- a/src/jvm/backtype/storm/clojure/RichShellSpout.java
+++ b/src/jvm/backtype/storm/clojure/RichShellSpout.java
@@ -1,0 +1,34 @@
+package backtype.storm.clojure;
+
+import backtype.storm.generated.StreamInfo;
+import backtype.storm.spout.ShellSpout;
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Fields;
+import java.util.Map;
+
+public class RichShellSpout extends ShellSpout implements IRichSpout {
+    private Map<String, StreamInfo> _outputs;
+
+    public RichShellSpout(String[] command, Map<String, StreamInfo> outputs) {
+        super(command);
+        _outputs = outputs;
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) {
+        for(String stream: _outputs.keySet()) {
+            StreamInfo def = _outputs.get(stream);
+            if(def.is_direct()) {
+                declarer.declareStream(stream, true, new Fields(def.get_output_fields()));
+            } else {
+                declarer.declareStream(stream, new Fields(def.get_output_fields()));
+            }
+        }
+    }
+
+    @Override
+    public Map<String, Object> getComponentConfiguration() {
+        return null;
+    }
+}

--- a/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -2,36 +2,107 @@ package backtype.storm.spout;
 
 import backtype.storm.generated.ShellComponent;
 import backtype.storm.task.TopologyContext;
+import backtype.storm.utils.ShellProcess;
+import backtype.storm.utils.Utils;
 import java.util.Map;
+import java.util.List;
+import java.io.IOException;
+import org.apache.log4j.Logger;
+import org.json.simple.JSONObject;
 
+import static backtype.storm.Config.TOPOLOGY_MAX_SPOUT_PENDING;
 
 public class ShellSpout implements ISpout {
+    public static Logger LOG = Logger.getLogger(ShellSpout.class);
+
+    private SpoutOutputCollector _collector;
+    private String[] _command;
+    private ShellProcess _process;
+
     public ShellSpout(ShellComponent component) {
         this(component.get_execution_command(), component.get_script());
     }
     
-    public ShellSpout(String shellCommand, String codeResource) {
-        
+    public ShellSpout(String... command) {
+        _command = command;
     }
     
-    public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
-        throw new UnsupportedOperationException("Not supported yet.");
+    public void open(Map stormConf, TopologyContext context,
+                     SpoutOutputCollector collector) {
+        _process = new ShellProcess(_command);
+        _collector = collector;
+
+        try {
+            String subpid = _process.launch(stormConf, context);
+            LOG.info("Launched subprocess with pid " + subpid);
+        } catch (IOException e) {
+            throw new RuntimeException("Error when launching multilang subprocess", e);
+        }
     }
 
     public void close() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        _process.destroy();
     }
 
+    private JSONObject _next;
     public void nextTuple() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (_next == null) {
+            _next = new JSONObject();
+            _next.put("command", "next");
+        }
+
+        querySubprocess(_next);
     }
 
+    private JSONObject _ack;
     public void ack(Object msgId) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (_ack == null) {
+            _ack = new JSONObject();
+            _ack.put("command", "ack");
+        }
+
+        _ack.put("id", msgId);
+        querySubprocess(_ack);
     }
 
+    private JSONObject _fail;
     public void fail(Object msgId) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        if (_fail == null) {
+            _fail = new JSONObject();
+            _fail.put("command", "fail");
+        }
+
+        _fail.put("id", msgId);
+        querySubprocess(_fail);
     }
 
+    private void querySubprocess(Object query) {
+        try {
+            _process.writeObject(query);
+
+            while (true) {
+                Map action = _process.readMap();
+                if (action == null) return; // sync
+                String command = (String) action.get("command");
+                if (command.equals("log")) {
+                    String msg = (String) action.get("msg");
+                    LOG.info("Shell msg: " + msg);
+                } else if (command.equals("emit")) {
+                    String stream = (String) action.get("stream");
+                    if (stream == null) stream = Utils.DEFAULT_STREAM_ID;
+                    Long task = (Long) action.get("task");
+                    List<Object> tuple = (List) action.get("tuple");
+                    Object messageId = (Object) action.get("id");
+                    if (task == null) {
+                        List<Integer> outtasks = _collector.emit(stream, tuple, messageId);
+                        _process.writeObject(outtasks);
+                    } else {
+                        _collector.emitDirect((int)task.longValue(), stream, tuple, messageId);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }

--- a/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/src/jvm/backtype/storm/task/ShellBolt.java
@@ -47,7 +47,7 @@ public class ShellBolt implements IBolt {
     public static Logger LOG = Logger.getLogger(ShellBolt.class);
     Process _subprocess;
     OutputCollector _collector;
-    Map<Long, Tuple> _inputs = new ConcurrentHashMap<Long, Tuple>();
+    Map<String, Tuple> _inputs = new ConcurrentHashMap<String, Tuple>();
 
     private String[] _command;
     private ShellProcess _process;
@@ -126,7 +126,7 @@ public class ShellBolt implements IBolt {
 
     public void execute(Tuple input) {
         //just need an id
-        long genId = MessageId.generateId();
+        String genId = Long.toString(MessageId.generateId());
         _inputs.put(genId, input);
         try {
             JSONObject obj = new JSONObject();
@@ -148,7 +148,7 @@ public class ShellBolt implements IBolt {
     }
 
     private void handleAck(Map action) {
-        Long id = (Long) action.get("id");
+        String id = (String) action.get("id");
         Tuple acked = _inputs.remove(id);
         if(acked==null) {
             throw new RuntimeException("Acked a non-existent or already acked/failed id: " + id);
@@ -157,7 +157,7 @@ public class ShellBolt implements IBolt {
     }
 
     private void handleFail(Map action) {
-        Long id = (Long) action.get("id");
+        String id = (String) action.get("id");
         Tuple failed = _inputs.remove(id);
         if(failed==null) {
             throw new RuntimeException("Failed a non-existent or already acked/failed id: " + id);
@@ -173,11 +173,11 @@ public class ShellBolt implements IBolt {
         List<Tuple> anchors = new ArrayList<Tuple>();
         Object anchorObj = action.get("anchors");
         if(anchorObj!=null) {
-            if(anchorObj instanceof Long) {
+            if(anchorObj instanceof String) {
                 anchorObj = Arrays.asList(anchorObj);
             }
             for(Object o: (List) anchorObj) {
-                Tuple t = _inputs.get((Long) o);
+                Tuple t = _inputs.get((String) o);
                 if (t == null) {
                     throw new RuntimeException("Anchored onto " + o + " after ack/fail");
                 }

--- a/src/jvm/backtype/storm/task/TopologyContext.java
+++ b/src/jvm/backtype/storm/task/TopologyContext.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang.NotImplementedException;
 import org.json.simple.JSONValue;
+import org.json.simple.JSONAware;
 
 /**
  * A TopologyContext is given to bolts and spouts in their "prepare" and "open"
@@ -29,7 +30,7 @@ import org.json.simple.JSONValue;
  * <p>The TopologyContext is also used to declare ISubscribedState objects to
  * synchronize state with StateSpouts this object is subscribed to.</p>
  */
-public class TopologyContext {
+public class TopologyContext implements JSONAware {
     private StormTopology _topology;
     private Map<Integer, String> _taskToComponent;
     private Integer _taskId;

--- a/src/jvm/backtype/storm/utils/ShellProcess.java
+++ b/src/jvm/backtype/storm/utils/ShellProcess.java
@@ -1,0 +1,99 @@
+package backtype.storm.utils;
+
+import backtype.storm.task.TopologyContext;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.List;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
+
+public class ShellProcess {
+    private DataOutputStream processIn;
+    private BufferedReader processOut;
+    private Process _subprocess;
+    private String[] command;
+
+    public ShellProcess(String[] command) {
+        this.command = command;
+    }
+
+    public String launch(Map conf, TopologyContext context) throws IOException {
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.directory(new File(context.getCodeDir()));
+        _subprocess = builder.start();
+
+        processIn = new DataOutputStream(_subprocess.getOutputStream());
+        processOut = new BufferedReader(new InputStreamReader(_subprocess.getInputStream()));
+
+        // this doesn't seem to work when the jvm dies due to at least
+        // some kinds of errors... does it help at all?
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            public void run() { _subprocess.destroy(); }
+        });
+
+        writeString(context.getPIDDir());
+        String pid = readString();
+        writeObject(conf);
+        writeObject(context);
+        return pid;
+    }
+
+    public void destroy() {
+        _subprocess.destroy();
+    }
+
+    public void writeObject(Object obj) throws IOException {
+        writeString(JSONValue.toJSONString(obj));
+    }
+
+    public void writeString(String string) throws IOException {
+        // don't need synchronization for now
+        //synchronized (processIn) {
+            processIn.writeBytes(string + "\nend\n");
+            processIn.flush();
+            //}
+    }
+
+    // returns null for sync. odd?
+    public Map readMap() throws IOException {
+        String string = readString();
+        if (string.equals("sync")) {
+            return null; // previously had: return readMap();
+        } else {
+            Map map = (Map)JSONValue.parse(string);
+            if (map != null) {
+                return map;
+            } else {
+                throw new IOException("unable to parse: " + string);
+            }
+        }
+    }
+
+    public String readString() throws IOException {
+        StringBuilder line = new StringBuilder();
+
+        //synchronized (processOut) {
+            while (true) {
+                String subline = processOut.readLine();
+                if(subline==null)
+                    throw new RuntimeException("Pipe to subprocess seems to be broken!");
+                if(subline.equals("sync")) {
+                    return subline;
+                }
+                if(subline.equals("end")) {
+                    break;
+                }
+                if(line.length()!=0) {
+                    line.append("\n");
+                }
+                line.append(subline);
+            }
+            //}
+
+        return line.toString();
+    }
+}

--- a/test/clj/backtype/storm/integration_test.clj
+++ b/test/clj/backtype/storm/integration_test.clj
@@ -65,7 +65,7 @@
     (let [nimbus (:nimbus cluster)
           topology (thrift/mk-topology
                       {"1" (thrift/mk-spout-spec (TestWordSpout. false))}
-                      {"2" (thrift/mk-shell-bolt-spec {"1" :shuffle} "python" "tester.py" ["word"] :parallelism-hint 1)}
+                      {"2" (thrift/mk-shell-bolt-spec {"1" :shuffle} ["python" "tester.py"] ["word"] :parallelism-hint 1)}
                       )]
       (submit-local-topology nimbus
                           "test"

--- a/test/clj/backtype/storm/integration_test.clj
+++ b/test/clj/backtype/storm/integration_test.clj
@@ -64,8 +64,8 @@
   (with-local-cluster [cluster :supervisors 4]
     (let [nimbus (:nimbus cluster)
           topology (thrift/mk-topology
-                      {"1" (thrift/mk-spout-spec (TestWordSpout. false))}
-                      {"2" (thrift/mk-shell-bolt-spec {"1" :shuffle} ["python" "tester.py"] ["word"] :parallelism-hint 1)}
+                      {"1" (thrift/mk-shell-spout-spec ["python" "tester_spout.py"] ["word"])}
+                      {"2" (thrift/mk-shell-bolt-spec {"1" :shuffle} ["python" "tester_bolt.py"] ["word"] :parallelism-hint 1)}
                       )]
       (submit-local-topology nimbus
                           "test"


### PR DESCRIPTION
The _readTaskIds/_readTuple trampoline/queue stuff in the Python implementation seems funny.. not sure about that — I am not fluent in Python. Still working on a node.js version where the lack of synchronization around task ids after emits is no problem.

I haven't yet tested reliable spouts. Will do that sometime soon.

I made a small change to the protocol, expecting and "end\n" after the pid as well, to be consistent. I could easily add back in the special case.
