### PR TITLE
prevent duplicates on Fields

### DIFF
--- a/src/jvm/backtype/storm/tuple/Fields.java
+++ b/src/jvm/backtype/storm/tuple/Fields.java
@@ -17,7 +17,14 @@ public class Fields implements Iterable<String>, Serializable {
     }
     
     public Fields(List<String> fields) {
-        _fields = new ArrayList<String>(fields);
+        _fields = new ArrayList<String>(fields.size());
+        for (String field : fields) {
+            if (_fields.contains(field))
+                throw new IllegalArgumentException(
+                    String.format("duplicate field '%s'", field)
+                );
+            _fields.add(field);
+        }
         index();
     }
     

--- a/test/clj/backtype/storm/fields_test.clj
+++ b/test/clj/backtype/storm/fields_test.clj
@@ -1,0 +1,40 @@
+(ns backtype.storm.fields-test
+  (:use [clojure test])
+  (:import [backtype.storm.tuple Fields])
+  (:import [java.util List])
+  (:import [java.util Iterator]))
+
+(deftest test-fields-constructor
+  (testing "constructor"
+    (testing "with (String... fields)"
+      (is (instance? Fields (Fields. (into-array String '("foo" "bar")))))
+      (is (thrown? IllegalArgumentException (Fields. (into-array String '("foo" "bar" "foo"))))))
+    (testing "with (List<String> fields)"
+      (is (instance? Fields (Fields. '("foo" "bar"))))
+      (is (thrown? IllegalArgumentException (Fields. '("foo" "bar" "foo")))))))
+
+(deftest test-fields-methods
+  (let [fields (Fields. '("foo" "bar"))]
+    (testing "method"
+      (testing ".size"
+        (is (= (.size fields) 2)))
+      (testing ".get"
+        (is (= (.get fields 0) "foo"))
+        (is (= (.get fields 1) "bar"))
+        (is (thrown? IndexOutOfBoundsException (.get fields 2))))
+      (testing ".fieldIndex"
+        (is (= (.fieldIndex fields "foo") 0))
+        (is (= (.fieldIndex fields "bar") 1))
+        (is (thrown? IllegalArgumentException (.fieldIndex fields "baz"))))
+      (testing ".toList"
+        (is (instance? List (.toList fields)))
+        (is (= (count (.toList fields)) 2))
+        (is (not-any? false? (map = (.toList fields) '("foo" "bar")))))
+      (testing ".iterator"
+        (is (instance? Iterator (.iterator fields)))
+        (is (= (count (iterator-seq (.iterator fields))) 2))
+        (is (not-any? false? (map = (iterator-seq (.iterator fields)) '("foo" "bar")))))
+      (testing ".select"
+        (is (instance? List (.select fields (Fields. '("bar")) '("a" "b" "c"))))
+        (is (= (.select fields (Fields. '("bar")) '("a" "b" "c")) '("b")))))))
+


### PR DESCRIPTION
Fields receives a list of strings that is stored internally on an ArrayList however it is indexed with a HashMap and field indexes can be retrieved by name (Tuple fields can be retrieved by name too) therefore Fields should prevent duplicates to avoid ambiguity and internal inconsistencies between _index and _fields.

I couldn't find tests for this class so I've added those as well.
