### PR TITLE
Simplify shell protocol

### DIFF
--- a/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -33,7 +33,7 @@ public class ShellSpout implements ISpout {
         _collector = collector;
 
         try {
-            String subpid = _process.launch(stormConf, context);
+            int subpid = _process.launch(stormConf, context);
             LOG.info("Launched subprocess with pid " + subpid);
         } catch (IOException e) {
             throw new RuntimeException("Error when launching multilang subprocess", e);
@@ -78,10 +78,10 @@ public class ShellSpout implements ISpout {
 
     private void querySubprocess(Object query) {
         try {
-            _process.writeObject(query);
+            _process.writeMessage(query);
 
             while (true) {
-                Map action = _process.readMap();
+                Map action = (Map)_process.readMessage();
                 if (action == null) return; // sync
                 String command = (String) action.get("command");
                 if (command.equals("log")) {
@@ -95,7 +95,7 @@ public class ShellSpout implements ISpout {
                     Object messageId = (Object) action.get("id");
                     if (task == null) {
                         List<Integer> outtasks = _collector.emit(stream, tuple, messageId);
-                        _process.writeObject(outtasks);
+                        _process.writeMessage(outtasks);
                     } else {
                         _collector.emitDirect((int)task.longValue(), stream, tuple, messageId);
                     }

--- a/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/src/jvm/backtype/storm/task/ShellBolt.java
@@ -72,7 +72,7 @@ public class ShellBolt implements IBolt {
 
         try {
             //subprocesses must send their pid first thing
-            String subpid = _process.launch(stormConf, context);
+            int subpid = _process.launch(stormConf, context);
             LOG.info("Launched subprocess with pid " + subpid);
         } catch (IOException e) {
             throw new RuntimeException("Error when launching multilang subprocess", e);
@@ -83,7 +83,7 @@ public class ShellBolt implements IBolt {
             public void run() {
                 while (_running) {
                     try {
-                        Map action = _process.readMap();
+                        Map action = (Map)_process.readMessage();
                         if (action == null) {
                             // ignore sync
                         }
@@ -115,7 +115,7 @@ public class ShellBolt implements IBolt {
                     try {
                         Object write = _pendingWrites.poll(1, SECONDS);
                         if (write != null) {
-                            _process.writeObject(write);
+                            _process.writeMessage(write);
                         }
                     } catch (IOException e) {
                         throw new RuntimeException(e);

--- a/src/multilang/py/storm.py
+++ b/src/multilang/py/storm.py
@@ -11,21 +11,18 @@ except ImportError:
 json_encode = lambda x: json.dumps(x)
 json_decode = lambda x: json.loads(x)
 
-def readStringMsg():
+#reads lines and reconstructs newlines appropriately
+def readMsg():
     msg = ""
     while True:
         line = sys.stdin.readline()[0:-1]
         if line == "end":
             break
         msg = msg + line + "\n"
-    return msg[0:-1]
+    return json_decode(msg[0:-1])
 
 MODE = None
 ANCHOR_TUPLE = None
-
-#reads lines and reconstructs newlines appropriately
-def readMsg():
-    return json_decode(readStringMsg())
 
 #queue up commands we read while trying to read taskids
 pending_commands = deque()
@@ -57,8 +54,8 @@ def readTuple():
     cmd = readCommand()
     return Tuple(cmd["id"], cmd["comp"], cmd["stream"], cmd["task"], cmd["tuple"])
 
-def sendToParent(s):
-    print s
+def sendMsgToParent(msg):
+    print json_encode(msg)
     print "end"
     sys.stdout.flush()
 
@@ -68,11 +65,8 @@ def sync():
 
 def sendpid(heartbeatdir):
     pid = os.getpid()
-    sendToParent(pid)
+    sendMsgToParent(pid)
     open(heartbeatdir + "/" + str(pid), "w").close()    
-
-def sendMsgToParent(amap):
-    sendToParent(json_encode(amap))
 
 def emit(*args, **kwargs):
     __emit(*args, **kwargs)
@@ -129,7 +123,7 @@ def readenv():
     return [conf, context]
 
 def initComponent():
-    heartbeatdir = readStringMsg()
+    heartbeatdir = readMsg()
     sendpid(heartbeatdir)
     return readenv()
 


### PR DESCRIPTION
Just uses JSON for everything, including the pid/piddir, which cleans up both the Java implementation and multilang implementations slightly.

This is currently based on your fix-shell-encoding.
