### PR TITLE
resolved the issue that when a topology has not been assigned a task, the storm-ui breaks

### DIFF
--- a/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/src/clj/backtype/storm/daemon/nimbus.clj
@@ -787,7 +787,10 @@
               task-info (storm-task-info storm-cluster-state storm-id)
               base (.storm-base storm-cluster-state storm-id nil)
               assignment (.assignment-info storm-cluster-state storm-id nil)
-              task-summaries (dofor [[task component] task-info]
+              no-assigned-tasks? (empty? (:task->node+port assignment))
+              task-summaries (if no-assigned-tasks?
+                               []
+                               (dofor [[task component] task-info]
                                     (let [[node port] (get-in assignment [:task->node+port task])
                                           host (-> assignment :node->host (get node))
                                           heartbeat (.task-heartbeat storm-cluster-state storm-id task)
@@ -806,7 +809,7 @@
                                                         errors
                                                         )
                                         (.set_stats stats))
-                                      ))
+                                      )))
               ]
           (TopologyInfo. storm-id
                          (:storm-name base)


### PR DESCRIPTION
for issue #92
