### PR TITLE
log warnning message when un-acked tuples in a bolt gets too large

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -75,6 +75,7 @@ topology.message.timeout.secs: 30
 topology.skip.missing.kryo.registrations: false
 topology.max.task.parallelism: null
 topology.max.spout.pending: null
+topology.max.bolt.pending: null
 topology.state.synchronization.timeout.secs: 60
 topology.stats.sample.rate: 0.05
 topology.fall.back.on.java.serialization: true

--- a/src/jvm/backtype/storm/Config.java
+++ b/src/jvm/backtype/storm/Config.java
@@ -347,7 +347,17 @@ public class Config extends HashMap<String, Object> {
      * their tuples with a message id.
      */
     public static String TOPOLOGY_MAX_SPOUT_PENDING="topology.max.spout.pending"; 
-    
+
+    /**
+     * The maximum number of tuples that can be pending on a bolt task at any given time. 
+     * This config applies to individual tasks, not to bolts or topologies as a whole. 
+     * 
+     * A pending tuple is one that has been emitted from a spout/bolt but has not been acked or failed yet.
+     * Note that unlike <code>TOPOLOGY_MAX_SPOUT_PENDING</code> this config parameter <strong>HAS</strong> 
+     * effect on all kinds of bolts (no matter the spout of the topology is reliable or not)
+     */
+    public static String TOPOLOGY_MAX_BOLT_PENDING="topology.max.bolt.pending"; 
+        
     /**
      * The maximum amount of time a component gives a source of state to synchronize before it requests
      * synchronization again.
@@ -465,6 +475,10 @@ public class Config extends HashMap<String, Object> {
     
     public void setMaxSpoutPending(int max) {
         put(Config.TOPOLOGY_MAX_SPOUT_PENDING, max);
+    }
+    
+    public void setMaxBoltPending(int max) {
+        put(Config.TOPOLOGY_MAX_BOLT_PENDING, max);
     }
     
     public void setStatsSampleRate(double rate) {


### PR DESCRIPTION
for issue #162 . I added a new config: **topology.max.blot.pending** to let user specify the threshold.
