### PR TITLE
Converted the DRPC mechanism to use binary (ByteBuffer) results sets but preserve String output for existing users.

### DIFF
--- a/src/clj/backtype/storm/LocalDRPC.clj
+++ b/src/clj/backtype/storm/LocalDRPC.clj
@@ -15,6 +15,10 @@
     [[] {:service-id id :handler handler}]
     ))
 
+(defn -executeBinary [this func funcArgs]
+  (.executeBinary (:handler (. this state)) func funcArgs)
+  )
+
 (defn -execute [this func funcArgs]
   (.execute (:handler (. this state)) func funcArgs)
   )

--- a/src/jvm/backtype/storm/ILocalDRPC.java
+++ b/src/jvm/backtype/storm/ILocalDRPC.java
@@ -3,8 +3,16 @@ package backtype.storm;
 import backtype.storm.daemon.Shutdownable;
 import backtype.storm.generated.DistributedRPC;
 import backtype.storm.generated.DistributedRPCInvocations;
+import backtype.storm.generated.DRPCExecutionException;
 
+import org.apache.thrift7.TException;
+import java.nio.charset.CharacterCodingException;
 
 public interface ILocalDRPC extends DistributedRPC.Iface, DistributedRPCInvocations.Iface, Shutdownable {
     public String getServiceId();    
+
+    /**
+    * Overloaded execute method for backwards compatibility
+    **/
+    // public String execute(String func, String args) throws TException, DRPCExecutionException, CharacterCodingException;
 }

--- a/src/jvm/backtype/storm/generated/DistributedRPC.java
+++ b/src/jvm/backtype/storm/generated/DistributedRPC.java
@@ -27,11 +27,15 @@ public class DistributedRPC {
 
     public String execute(String functionName, String funcArgs) throws DRPCExecutionException, org.apache.thrift7.TException;
 
+    public ByteBuffer executeBinary(String functionName, String funcArgs) throws DRPCExecutionException, org.apache.thrift7.TException;
+
   }
 
   public interface AsyncIface {
 
     public void execute(String functionName, String funcArgs, org.apache.thrift7.async.AsyncMethodCallback<AsyncClient.execute_call> resultHandler) throws org.apache.thrift7.TException;
+
+    public void executeBinary(String functionName, String funcArgs, org.apache.thrift7.async.AsyncMethodCallback<AsyncClient.executeBinary_call> resultHandler) throws org.apache.thrift7.TException;
 
   }
 
@@ -80,6 +84,33 @@ public class DistributedRPC {
         throw result.e;
       }
       throw new org.apache.thrift7.TApplicationException(org.apache.thrift7.TApplicationException.MISSING_RESULT, "execute failed: unknown result");
+    }
+
+    public ByteBuffer executeBinary(String functionName, String funcArgs) throws DRPCExecutionException, org.apache.thrift7.TException
+    {
+      send_executeBinary(functionName, funcArgs);
+      return recv_executeBinary();
+    }
+
+    public void send_executeBinary(String functionName, String funcArgs) throws org.apache.thrift7.TException
+    {
+      executeBinary_args args = new executeBinary_args();
+      args.set_functionName(functionName);
+      args.set_funcArgs(funcArgs);
+      sendBase("executeBinary", args);
+    }
+
+    public ByteBuffer recv_executeBinary() throws DRPCExecutionException, org.apache.thrift7.TException
+    {
+      executeBinary_result result = new executeBinary_result();
+      receiveBase(result, "executeBinary");
+      if (result.is_set_success()) {
+        return result.success;
+      }
+      if (result.e != null) {
+        throw result.e;
+      }
+      throw new org.apache.thrift7.TApplicationException(org.apache.thrift7.TApplicationException.MISSING_RESULT, "executeBinary failed: unknown result");
     }
 
   }
@@ -135,6 +166,41 @@ public class DistributedRPC {
       }
     }
 
+    public void executeBinary(String functionName, String funcArgs, org.apache.thrift7.async.AsyncMethodCallback<executeBinary_call> resultHandler) throws org.apache.thrift7.TException {
+      checkReady();
+      executeBinary_call method_call = new executeBinary_call(functionName, funcArgs, resultHandler, this, ___protocolFactory, ___transport);
+      this.___currentMethod = method_call;
+      ___manager.call(method_call);
+    }
+
+    public static class executeBinary_call extends org.apache.thrift7.async.TAsyncMethodCall {
+      private String functionName;
+      private String funcArgs;
+      public executeBinary_call(String functionName, String funcArgs, org.apache.thrift7.async.AsyncMethodCallback<executeBinary_call> resultHandler, org.apache.thrift7.async.TAsyncClient client, org.apache.thrift7.protocol.TProtocolFactory protocolFactory, org.apache.thrift7.transport.TNonblockingTransport transport) throws org.apache.thrift7.TException {
+        super(client, protocolFactory, transport, resultHandler, false);
+        this.functionName = functionName;
+        this.funcArgs = funcArgs;
+      }
+
+      public void write_args(org.apache.thrift7.protocol.TProtocol prot) throws org.apache.thrift7.TException {
+        prot.writeMessageBegin(new org.apache.thrift7.protocol.TMessage("executeBinary", org.apache.thrift7.protocol.TMessageType.CALL, 0));
+        executeBinary_args args = new executeBinary_args();
+        args.set_functionName(functionName);
+        args.set_funcArgs(funcArgs);
+        args.write(prot);
+        prot.writeMessageEnd();
+      }
+
+      public ByteBuffer getResult() throws DRPCExecutionException, org.apache.thrift7.TException {
+        if (getState() != org.apache.thrift7.async.TAsyncMethodCall.State.RESPONSE_READ) {
+          throw new IllegalStateException("Method call not finished!");
+        }
+        org.apache.thrift7.transport.TMemoryInputTransport memoryTransport = new org.apache.thrift7.transport.TMemoryInputTransport(getFrameBuffer().array());
+        org.apache.thrift7.protocol.TProtocol prot = client.getProtocolFactory().getProtocol(memoryTransport);
+        return (new Client(prot)).recv_executeBinary();
+      }
+    }
+
   }
 
   public static class Processor<I extends Iface> extends org.apache.thrift7.TBaseProcessor implements org.apache.thrift7.TProcessor {
@@ -149,6 +215,7 @@ public class DistributedRPC {
 
     private static <I extends Iface> Map<String,  org.apache.thrift7.ProcessFunction<I, ? extends  org.apache.thrift7.TBase>> getProcessMap(Map<String,  org.apache.thrift7.ProcessFunction<I, ? extends  org.apache.thrift7.TBase>> processMap) {
       processMap.put("execute", new execute());
+      processMap.put("executeBinary", new executeBinary());
       return processMap;
     }
 
@@ -165,6 +232,26 @@ public class DistributedRPC {
         execute_result result = new execute_result();
         try {
           result.success = iface.execute(args.functionName, args.funcArgs);
+        } catch (DRPCExecutionException e) {
+          result.e = e;
+        }
+        return result;
+      }
+    }
+
+    private static class executeBinary<I extends Iface> extends org.apache.thrift7.ProcessFunction<I, executeBinary_args> {
+      public executeBinary() {
+        super("executeBinary");
+      }
+
+      protected executeBinary_args getEmptyArgsInstance() {
+        return new executeBinary_args();
+      }
+
+      protected executeBinary_result getResult(I iface, executeBinary_args args) throws org.apache.thrift7.TException {
+        executeBinary_result result = new executeBinary_result();
+        try {
+          result.success = iface.executeBinary(args.functionName, args.funcArgs);
         } catch (DRPCExecutionException e) {
           result.e = e;
         }
@@ -925,6 +1012,803 @@ public class DistributedRPC {
         sb.append("null");
       } else {
         sb.append(this.success);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("e:");
+      if (this.e == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.e);
+      }
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift7.TException {
+      // check for required fields
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift7.protocol.TCompactProtocol(new org.apache.thrift7.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift7.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        read(new org.apache.thrift7.protocol.TCompactProtocol(new org.apache.thrift7.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift7.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+  }
+
+  public static class executeBinary_args implements org.apache.thrift7.TBase<executeBinary_args, executeBinary_args._Fields>, java.io.Serializable, Cloneable   {
+    private static final org.apache.thrift7.protocol.TStruct STRUCT_DESC = new org.apache.thrift7.protocol.TStruct("executeBinary_args");
+
+    private static final org.apache.thrift7.protocol.TField FUNCTION_NAME_FIELD_DESC = new org.apache.thrift7.protocol.TField("functionName", org.apache.thrift7.protocol.TType.STRING, (short)1);
+    private static final org.apache.thrift7.protocol.TField FUNC_ARGS_FIELD_DESC = new org.apache.thrift7.protocol.TField("funcArgs", org.apache.thrift7.protocol.TType.STRING, (short)2);
+
+    private String functionName; // required
+    private String funcArgs; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift7.TFieldIdEnum {
+      FUNCTION_NAME((short)1, "functionName"),
+      FUNC_ARGS((short)2, "funcArgs");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 1: // FUNCTION_NAME
+            return FUNCTION_NAME;
+          case 2: // FUNC_ARGS
+            return FUNC_ARGS;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+
+    public static final Map<_Fields, org.apache.thrift7.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift7.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift7.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.FUNCTION_NAME, new org.apache.thrift7.meta_data.FieldMetaData("functionName", org.apache.thrift7.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRING)));
+      tmpMap.put(_Fields.FUNC_ARGS, new org.apache.thrift7.meta_data.FieldMetaData("funcArgs", org.apache.thrift7.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRING)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift7.meta_data.FieldMetaData.addStructMetaDataMap(executeBinary_args.class, metaDataMap);
+    }
+
+    public executeBinary_args() {
+    }
+
+    public executeBinary_args(
+      String functionName,
+      String funcArgs)
+    {
+      this();
+      this.functionName = functionName;
+      this.funcArgs = funcArgs;
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public executeBinary_args(executeBinary_args other) {
+      if (other.is_set_functionName()) {
+        this.functionName = other.functionName;
+      }
+      if (other.is_set_funcArgs()) {
+        this.funcArgs = other.funcArgs;
+      }
+    }
+
+    public executeBinary_args deepCopy() {
+      return new executeBinary_args(this);
+    }
+
+    @Override
+    public void clear() {
+      this.functionName = null;
+      this.funcArgs = null;
+    }
+
+    public String get_functionName() {
+      return this.functionName;
+    }
+
+    public void set_functionName(String functionName) {
+      this.functionName = functionName;
+    }
+
+    public void unset_functionName() {
+      this.functionName = null;
+    }
+
+    /** Returns true if field functionName is set (has been assigned a value) and false otherwise */
+    public boolean is_set_functionName() {
+      return this.functionName != null;
+    }
+
+    public void set_functionName_isSet(boolean value) {
+      if (!value) {
+        this.functionName = null;
+      }
+    }
+
+    public String get_funcArgs() {
+      return this.funcArgs;
+    }
+
+    public void set_funcArgs(String funcArgs) {
+      this.funcArgs = funcArgs;
+    }
+
+    public void unset_funcArgs() {
+      this.funcArgs = null;
+    }
+
+    /** Returns true if field funcArgs is set (has been assigned a value) and false otherwise */
+    public boolean is_set_funcArgs() {
+      return this.funcArgs != null;
+    }
+
+    public void set_funcArgs_isSet(boolean value) {
+      if (!value) {
+        this.funcArgs = null;
+      }
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case FUNCTION_NAME:
+        if (value == null) {
+          unset_functionName();
+        } else {
+          set_functionName((String)value);
+        }
+        break;
+
+      case FUNC_ARGS:
+        if (value == null) {
+          unset_funcArgs();
+        } else {
+          set_funcArgs((String)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case FUNCTION_NAME:
+        return get_functionName();
+
+      case FUNC_ARGS:
+        return get_funcArgs();
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case FUNCTION_NAME:
+        return is_set_functionName();
+      case FUNC_ARGS:
+        return is_set_funcArgs();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof executeBinary_args)
+        return this.equals((executeBinary_args)that);
+      return false;
+    }
+
+    public boolean equals(executeBinary_args that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_functionName = true && this.is_set_functionName();
+      boolean that_present_functionName = true && that.is_set_functionName();
+      if (this_present_functionName || that_present_functionName) {
+        if (!(this_present_functionName && that_present_functionName))
+          return false;
+        if (!this.functionName.equals(that.functionName))
+          return false;
+      }
+
+      boolean this_present_funcArgs = true && this.is_set_funcArgs();
+      boolean that_present_funcArgs = true && that.is_set_funcArgs();
+      if (this_present_funcArgs || that_present_funcArgs) {
+        if (!(this_present_funcArgs && that_present_funcArgs))
+          return false;
+        if (!this.funcArgs.equals(that.funcArgs))
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      HashCodeBuilder builder = new HashCodeBuilder();
+
+      boolean present_functionName = true && (is_set_functionName());
+      builder.append(present_functionName);
+      if (present_functionName)
+        builder.append(functionName);
+
+      boolean present_funcArgs = true && (is_set_funcArgs());
+      builder.append(present_funcArgs);
+      if (present_funcArgs)
+        builder.append(funcArgs);
+
+      return builder.toHashCode();
+    }
+
+    public int compareTo(executeBinary_args other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+      executeBinary_args typedOther = (executeBinary_args)other;
+
+      lastComparison = Boolean.valueOf(is_set_functionName()).compareTo(typedOther.is_set_functionName());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_functionName()) {
+        lastComparison = org.apache.thrift7.TBaseHelper.compareTo(this.functionName, typedOther.functionName);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = Boolean.valueOf(is_set_funcArgs()).compareTo(typedOther.is_set_funcArgs());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_funcArgs()) {
+        lastComparison = org.apache.thrift7.TBaseHelper.compareTo(this.funcArgs, typedOther.funcArgs);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift7.protocol.TProtocol iprot) throws org.apache.thrift7.TException {
+      org.apache.thrift7.protocol.TField field;
+      iprot.readStructBegin();
+      while (true)
+      {
+        field = iprot.readFieldBegin();
+        if (field.type == org.apache.thrift7.protocol.TType.STOP) { 
+          break;
+        }
+        switch (field.id) {
+          case 1: // FUNCTION_NAME
+            if (field.type == org.apache.thrift7.protocol.TType.STRING) {
+              this.functionName = iprot.readString();
+            } else { 
+              org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
+            }
+            break;
+          case 2: // FUNC_ARGS
+            if (field.type == org.apache.thrift7.protocol.TType.STRING) {
+              this.funcArgs = iprot.readString();
+            } else { 
+              org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
+            }
+            break;
+          default:
+            org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
+        }
+        iprot.readFieldEnd();
+      }
+      iprot.readStructEnd();
+      validate();
+    }
+
+    public void write(org.apache.thrift7.protocol.TProtocol oprot) throws org.apache.thrift7.TException {
+      validate();
+
+      oprot.writeStructBegin(STRUCT_DESC);
+      if (this.functionName != null) {
+        oprot.writeFieldBegin(FUNCTION_NAME_FIELD_DESC);
+        oprot.writeString(this.functionName);
+        oprot.writeFieldEnd();
+      }
+      if (this.funcArgs != null) {
+        oprot.writeFieldBegin(FUNC_ARGS_FIELD_DESC);
+        oprot.writeString(this.funcArgs);
+        oprot.writeFieldEnd();
+      }
+      oprot.writeFieldStop();
+      oprot.writeStructEnd();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("executeBinary_args(");
+      boolean first = true;
+
+      sb.append("functionName:");
+      if (this.functionName == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.functionName);
+      }
+      first = false;
+      if (!first) sb.append(", ");
+      sb.append("funcArgs:");
+      if (this.funcArgs == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.funcArgs);
+      }
+      first = false;
+      sb.append(")");
+      return sb.toString();
+    }
+
+    public void validate() throws org.apache.thrift7.TException {
+      // check for required fields
+    }
+
+    private void writeObject(java.io.ObjectOutputStream out) throws java.io.IOException {
+      try {
+        write(new org.apache.thrift7.protocol.TCompactProtocol(new org.apache.thrift7.transport.TIOStreamTransport(out)));
+      } catch (org.apache.thrift7.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+    private void readObject(java.io.ObjectInputStream in) throws java.io.IOException, ClassNotFoundException {
+      try {
+        read(new org.apache.thrift7.protocol.TCompactProtocol(new org.apache.thrift7.transport.TIOStreamTransport(in)));
+      } catch (org.apache.thrift7.TException te) {
+        throw new java.io.IOException(te);
+      }
+    }
+
+  }
+
+  public static class executeBinary_result implements org.apache.thrift7.TBase<executeBinary_result, executeBinary_result._Fields>, java.io.Serializable, Cloneable   {
+    private static final org.apache.thrift7.protocol.TStruct STRUCT_DESC = new org.apache.thrift7.protocol.TStruct("executeBinary_result");
+
+    private static final org.apache.thrift7.protocol.TField SUCCESS_FIELD_DESC = new org.apache.thrift7.protocol.TField("success", org.apache.thrift7.protocol.TType.STRING, (short)0);
+    private static final org.apache.thrift7.protocol.TField E_FIELD_DESC = new org.apache.thrift7.protocol.TField("e", org.apache.thrift7.protocol.TType.STRUCT, (short)1);
+
+    private ByteBuffer success; // required
+    private DRPCExecutionException e; // required
+
+    /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
+    public enum _Fields implements org.apache.thrift7.TFieldIdEnum {
+      SUCCESS((short)0, "success"),
+      E((short)1, "e");
+
+      private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
+
+      static {
+        for (_Fields field : EnumSet.allOf(_Fields.class)) {
+          byName.put(field.getFieldName(), field);
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, or null if its not found.
+       */
+      public static _Fields findByThriftId(int fieldId) {
+        switch(fieldId) {
+          case 0: // SUCCESS
+            return SUCCESS;
+          case 1: // E
+            return E;
+          default:
+            return null;
+        }
+      }
+
+      /**
+       * Find the _Fields constant that matches fieldId, throwing an exception
+       * if it is not found.
+       */
+      public static _Fields findByThriftIdOrThrow(int fieldId) {
+        _Fields fields = findByThriftId(fieldId);
+        if (fields == null) throw new IllegalArgumentException("Field " + fieldId + " doesn't exist!");
+        return fields;
+      }
+
+      /**
+       * Find the _Fields constant that matches name, or null if its not found.
+       */
+      public static _Fields findByName(String name) {
+        return byName.get(name);
+      }
+
+      private final short _thriftId;
+      private final String _fieldName;
+
+      _Fields(short thriftId, String fieldName) {
+        _thriftId = thriftId;
+        _fieldName = fieldName;
+      }
+
+      public short getThriftFieldId() {
+        return _thriftId;
+      }
+
+      public String getFieldName() {
+        return _fieldName;
+      }
+    }
+
+    // isset id assignments
+
+    public static final Map<_Fields, org.apache.thrift7.meta_data.FieldMetaData> metaDataMap;
+    static {
+      Map<_Fields, org.apache.thrift7.meta_data.FieldMetaData> tmpMap = new EnumMap<_Fields, org.apache.thrift7.meta_data.FieldMetaData>(_Fields.class);
+      tmpMap.put(_Fields.SUCCESS, new org.apache.thrift7.meta_data.FieldMetaData("success", org.apache.thrift7.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRING          , true)));
+      tmpMap.put(_Fields.E, new org.apache.thrift7.meta_data.FieldMetaData("e", org.apache.thrift7.TFieldRequirementType.DEFAULT, 
+          new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRUCT)));
+      metaDataMap = Collections.unmodifiableMap(tmpMap);
+      org.apache.thrift7.meta_data.FieldMetaData.addStructMetaDataMap(executeBinary_result.class, metaDataMap);
+    }
+
+    public executeBinary_result() {
+    }
+
+    public executeBinary_result(
+      ByteBuffer success,
+      DRPCExecutionException e)
+    {
+      this();
+      this.success = success;
+      this.e = e;
+    }
+
+    /**
+     * Performs a deep copy on <i>other</i>.
+     */
+    public executeBinary_result(executeBinary_result other) {
+      if (other.is_set_success()) {
+        this.success = org.apache.thrift7.TBaseHelper.copyBinary(other.success);
+;
+      }
+      if (other.is_set_e()) {
+        this.e = new DRPCExecutionException(other.e);
+      }
+    }
+
+    public executeBinary_result deepCopy() {
+      return new executeBinary_result(this);
+    }
+
+    @Override
+    public void clear() {
+      this.success = null;
+      this.e = null;
+    }
+
+    public byte[] get_success() {
+      set_success(org.apache.thrift7.TBaseHelper.rightSize(success));
+      return success == null ? null : success.array();
+    }
+
+    public ByteBuffer buffer_for_success() {
+      return success;
+    }
+
+    public void set_success(byte[] success) {
+      set_success(success == null ? (ByteBuffer)null : ByteBuffer.wrap(success));
+    }
+
+    public void set_success(ByteBuffer success) {
+      this.success = success;
+    }
+
+    public void unset_success() {
+      this.success = null;
+    }
+
+    /** Returns true if field success is set (has been assigned a value) and false otherwise */
+    public boolean is_set_success() {
+      return this.success != null;
+    }
+
+    public void set_success_isSet(boolean value) {
+      if (!value) {
+        this.success = null;
+      }
+    }
+
+    public DRPCExecutionException get_e() {
+      return this.e;
+    }
+
+    public void set_e(DRPCExecutionException e) {
+      this.e = e;
+    }
+
+    public void unset_e() {
+      this.e = null;
+    }
+
+    /** Returns true if field e is set (has been assigned a value) and false otherwise */
+    public boolean is_set_e() {
+      return this.e != null;
+    }
+
+    public void set_e_isSet(boolean value) {
+      if (!value) {
+        this.e = null;
+      }
+    }
+
+    public void setFieldValue(_Fields field, Object value) {
+      switch (field) {
+      case SUCCESS:
+        if (value == null) {
+          unset_success();
+        } else {
+          set_success((ByteBuffer)value);
+        }
+        break;
+
+      case E:
+        if (value == null) {
+          unset_e();
+        } else {
+          set_e((DRPCExecutionException)value);
+        }
+        break;
+
+      }
+    }
+
+    public Object getFieldValue(_Fields field) {
+      switch (field) {
+      case SUCCESS:
+        return get_success();
+
+      case E:
+        return get_e();
+
+      }
+      throw new IllegalStateException();
+    }
+
+    /** Returns true if field corresponding to fieldID is set (has been assigned a value) and false otherwise */
+    public boolean isSet(_Fields field) {
+      if (field == null) {
+        throw new IllegalArgumentException();
+      }
+
+      switch (field) {
+      case SUCCESS:
+        return is_set_success();
+      case E:
+        return is_set_e();
+      }
+      throw new IllegalStateException();
+    }
+
+    @Override
+    public boolean equals(Object that) {
+      if (that == null)
+        return false;
+      if (that instanceof executeBinary_result)
+        return this.equals((executeBinary_result)that);
+      return false;
+    }
+
+    public boolean equals(executeBinary_result that) {
+      if (that == null)
+        return false;
+
+      boolean this_present_success = true && this.is_set_success();
+      boolean that_present_success = true && that.is_set_success();
+      if (this_present_success || that_present_success) {
+        if (!(this_present_success && that_present_success))
+          return false;
+        if (!this.success.equals(that.success))
+          return false;
+      }
+
+      boolean this_present_e = true && this.is_set_e();
+      boolean that_present_e = true && that.is_set_e();
+      if (this_present_e || that_present_e) {
+        if (!(this_present_e && that_present_e))
+          return false;
+        if (!this.e.equals(that.e))
+          return false;
+      }
+
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      HashCodeBuilder builder = new HashCodeBuilder();
+
+      boolean present_success = true && (is_set_success());
+      builder.append(present_success);
+      if (present_success)
+        builder.append(success);
+
+      boolean present_e = true && (is_set_e());
+      builder.append(present_e);
+      if (present_e)
+        builder.append(e);
+
+      return builder.toHashCode();
+    }
+
+    public int compareTo(executeBinary_result other) {
+      if (!getClass().equals(other.getClass())) {
+        return getClass().getName().compareTo(other.getClass().getName());
+      }
+
+      int lastComparison = 0;
+      executeBinary_result typedOther = (executeBinary_result)other;
+
+      lastComparison = Boolean.valueOf(is_set_success()).compareTo(typedOther.is_set_success());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_success()) {
+        lastComparison = org.apache.thrift7.TBaseHelper.compareTo(this.success, typedOther.success);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      lastComparison = Boolean.valueOf(is_set_e()).compareTo(typedOther.is_set_e());
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+      if (is_set_e()) {
+        lastComparison = org.apache.thrift7.TBaseHelper.compareTo(this.e, typedOther.e);
+        if (lastComparison != 0) {
+          return lastComparison;
+        }
+      }
+      return 0;
+    }
+
+    public _Fields fieldForId(int fieldId) {
+      return _Fields.findByThriftId(fieldId);
+    }
+
+    public void read(org.apache.thrift7.protocol.TProtocol iprot) throws org.apache.thrift7.TException {
+      org.apache.thrift7.protocol.TField field;
+      iprot.readStructBegin();
+      while (true)
+      {
+        field = iprot.readFieldBegin();
+        if (field.type == org.apache.thrift7.protocol.TType.STOP) { 
+          break;
+        }
+        switch (field.id) {
+          case 0: // SUCCESS
+            if (field.type == org.apache.thrift7.protocol.TType.STRING) {
+              this.success = iprot.readBinary();
+            } else { 
+              org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
+            }
+            break;
+          case 1: // E
+            if (field.type == org.apache.thrift7.protocol.TType.STRUCT) {
+              this.e = new DRPCExecutionException();
+              this.e.read(iprot);
+            } else { 
+              org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
+            }
+            break;
+          default:
+            org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
+        }
+        iprot.readFieldEnd();
+      }
+      iprot.readStructEnd();
+      validate();
+    }
+
+    public void write(org.apache.thrift7.protocol.TProtocol oprot) throws org.apache.thrift7.TException {
+      oprot.writeStructBegin(STRUCT_DESC);
+
+      if (this.is_set_success()) {
+        oprot.writeFieldBegin(SUCCESS_FIELD_DESC);
+        oprot.writeBinary(this.success);
+        oprot.writeFieldEnd();
+      } else if (this.is_set_e()) {
+        oprot.writeFieldBegin(E_FIELD_DESC);
+        this.e.write(oprot);
+        oprot.writeFieldEnd();
+      }
+      oprot.writeFieldStop();
+      oprot.writeStructEnd();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("executeBinary_result(");
+      boolean first = true;
+
+      sb.append("success:");
+      if (this.success == null) {
+        sb.append("null");
+      } else {
+        org.apache.thrift7.TBaseHelper.toString(this.success, sb);
       }
       first = false;
       if (!first) sb.append(", ");

--- a/src/jvm/backtype/storm/generated/DistributedRPCInvocations.java
+++ b/src/jvm/backtype/storm/generated/DistributedRPCInvocations.java
@@ -25,7 +25,7 @@ public class DistributedRPCInvocations {
 
   public interface Iface {
 
-    public void result(String id, String result) throws org.apache.thrift7.TException;
+    public void result(String id, ByteBuffer result) throws org.apache.thrift7.TException;
 
     public DRPCRequest fetchRequest(String functionName) throws org.apache.thrift7.TException;
 
@@ -35,7 +35,7 @@ public class DistributedRPCInvocations {
 
   public interface AsyncIface {
 
-    public void result(String id, String result, org.apache.thrift7.async.AsyncMethodCallback<AsyncClient.result_call> resultHandler) throws org.apache.thrift7.TException;
+    public void result(String id, ByteBuffer result, org.apache.thrift7.async.AsyncMethodCallback<AsyncClient.result_call> resultHandler) throws org.apache.thrift7.TException;
 
     public void fetchRequest(String functionName, org.apache.thrift7.async.AsyncMethodCallback<AsyncClient.fetchRequest_call> resultHandler) throws org.apache.thrift7.TException;
 
@@ -63,13 +63,13 @@ public class DistributedRPCInvocations {
       super(iprot, oprot);
     }
 
-    public void result(String id, String result) throws org.apache.thrift7.TException
+    public void result(String id, ByteBuffer result) throws org.apache.thrift7.TException
     {
       send_result(id, result);
       recv_result();
     }
 
-    public void send_result(String id, String result) throws org.apache.thrift7.TException
+    public void send_result(String id, ByteBuffer result) throws org.apache.thrift7.TException
     {
       result_args args = new result_args();
       args.set_id(id);
@@ -145,7 +145,7 @@ public class DistributedRPCInvocations {
       super(protocolFactory, clientManager, transport);
     }
 
-    public void result(String id, String result, org.apache.thrift7.async.AsyncMethodCallback<result_call> resultHandler) throws org.apache.thrift7.TException {
+    public void result(String id, ByteBuffer result, org.apache.thrift7.async.AsyncMethodCallback<result_call> resultHandler) throws org.apache.thrift7.TException {
       checkReady();
       result_call method_call = new result_call(id, result, resultHandler, this, ___protocolFactory, ___transport);
       this.___currentMethod = method_call;
@@ -154,8 +154,8 @@ public class DistributedRPCInvocations {
 
     public static class result_call extends org.apache.thrift7.async.TAsyncMethodCall {
       private String id;
-      private String result;
-      public result_call(String id, String result, org.apache.thrift7.async.AsyncMethodCallback<result_call> resultHandler, org.apache.thrift7.async.TAsyncClient client, org.apache.thrift7.protocol.TProtocolFactory protocolFactory, org.apache.thrift7.transport.TNonblockingTransport transport) throws org.apache.thrift7.TException {
+      private ByteBuffer result;
+      public result_call(String id, ByteBuffer result, org.apache.thrift7.async.AsyncMethodCallback<result_call> resultHandler, org.apache.thrift7.async.TAsyncClient client, org.apache.thrift7.protocol.TProtocolFactory protocolFactory, org.apache.thrift7.transport.TNonblockingTransport transport) throws org.apache.thrift7.TException {
         super(client, protocolFactory, transport, resultHandler, false);
         this.id = id;
         this.result = result;
@@ -320,7 +320,7 @@ public class DistributedRPCInvocations {
     private static final org.apache.thrift7.protocol.TField RESULT_FIELD_DESC = new org.apache.thrift7.protocol.TField("result", org.apache.thrift7.protocol.TType.STRING, (short)2);
 
     private String id; // required
-    private String result; // required
+    private ByteBuffer result; // required
 
     /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
     public enum _Fields implements org.apache.thrift7.TFieldIdEnum {
@@ -391,7 +391,7 @@ public class DistributedRPCInvocations {
       tmpMap.put(_Fields.ID, new org.apache.thrift7.meta_data.FieldMetaData("id", org.apache.thrift7.TFieldRequirementType.DEFAULT, 
           new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRING)));
       tmpMap.put(_Fields.RESULT, new org.apache.thrift7.meta_data.FieldMetaData("result", org.apache.thrift7.TFieldRequirementType.DEFAULT, 
-          new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRING)));
+          new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRING          , true)));
       metaDataMap = Collections.unmodifiableMap(tmpMap);
       org.apache.thrift7.meta_data.FieldMetaData.addStructMetaDataMap(result_args.class, metaDataMap);
     }
@@ -401,7 +401,7 @@ public class DistributedRPCInvocations {
 
     public result_args(
       String id,
-      String result)
+      ByteBuffer result)
     {
       this();
       this.id = id;
@@ -416,7 +416,8 @@ public class DistributedRPCInvocations {
         this.id = other.id;
       }
       if (other.is_set_result()) {
-        this.result = other.result;
+        this.result = org.apache.thrift7.TBaseHelper.copyBinary(other.result);
+;
       }
     }
 
@@ -453,11 +454,20 @@ public class DistributedRPCInvocations {
       }
     }
 
-    public String get_result() {
-      return this.result;
+    public byte[] get_result() {
+      set_result(org.apache.thrift7.TBaseHelper.rightSize(result));
+      return result == null ? null : result.array();
     }
 
-    public void set_result(String result) {
+    public ByteBuffer buffer_for_result() {
+      return result;
+    }
+
+    public void set_result(byte[] result) {
+      set_result(result == null ? (ByteBuffer)null : ByteBuffer.wrap(result));
+    }
+
+    public void set_result(ByteBuffer result) {
       this.result = result;
     }
 
@@ -490,7 +500,7 @@ public class DistributedRPCInvocations {
         if (value == null) {
           unset_result();
         } else {
-          set_result((String)value);
+          set_result((ByteBuffer)value);
         }
         break;
 
@@ -629,7 +639,7 @@ public class DistributedRPCInvocations {
             break;
           case 2: // RESULT
             if (field.type == org.apache.thrift7.protocol.TType.STRING) {
-              this.result = iprot.readString();
+              this.result = iprot.readBinary();
             } else { 
               org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
             }
@@ -654,7 +664,7 @@ public class DistributedRPCInvocations {
       }
       if (this.result != null) {
         oprot.writeFieldBegin(RESULT_FIELD_DESC);
-        oprot.writeString(this.result);
+        oprot.writeBinary(this.result);
         oprot.writeFieldEnd();
       }
       oprot.writeFieldStop();
@@ -678,7 +688,7 @@ public class DistributedRPCInvocations {
       if (this.result == null) {
         sb.append("null");
       } else {
-        sb.append(this.result);
+        org.apache.thrift7.TBaseHelper.toString(this.result, sb);
       }
       first = false;
       sb.append(")");

--- a/src/jvm/backtype/storm/utils/DRPCClient.java
+++ b/src/jvm/backtype/storm/utils/DRPCClient.java
@@ -8,6 +8,10 @@ import org.apache.thrift7.transport.TFramedTransport;
 import org.apache.thrift7.transport.TSocket;
 import org.apache.thrift7.transport.TTransport;
 
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.*;
+
 public class DRPCClient implements DistributedRPC.Iface {
     private TTransport conn;
     private DistributedRPC.Client client;
@@ -48,10 +52,41 @@ public class DRPCClient implements DistributedRPC.Iface {
         return port;
     }   
     
+    
+    /**
+     * Wraps the executeBinary method, turning the ByteBuffer into a String. Required for backwards compatibility.
+     * @param func
+     * @param args
+     * @return
+     * @throws TException
+     * @throws DRPCExecutionException
+     */
     public String execute(String func, String args) throws TException, DRPCExecutionException {
         try {
+            ByteBuffer byteBuffer = executeBinary( func, args );
+            Charset charset = Charset.defaultCharset();
+
+            CharsetDecoder decoder = charset.newDecoder();  
+            CharBuffer charBuffer = decoder.decode(byteBuffer);  
+            String s = charBuffer.toString();           
+            
+            return s;
+        } catch(TException e) {
+            client = null;
+            throw e;
+        } catch( java.nio.charset.CharacterCodingException e ) {
+            client = null;
+            throw new DRPCExecutionException( "Error encoding characters: " + e.toString() );
+        } catch(DRPCExecutionException e) {
+            client = null;
+            throw e;
+        }
+    }
+
+    public ByteBuffer executeBinary(String func, String args) throws TException, DRPCExecutionException {
+        try {
             if(client==null) connect();
-            return client.execute(func, args);
+            return client.executeBinary(func, args);
         } catch(TException e) {
             client = null;
             throw e;
@@ -60,7 +95,7 @@ public class DRPCClient implements DistributedRPC.Iface {
             throw e;
         }
     }
-
+    
     public void close() {
         conn.close();
     }

--- a/src/py/storm/DistributedRPC-remote
+++ b/src/py/storm/DistributedRPC-remote
@@ -22,6 +22,7 @@ if len(sys.argv) <= 1 or sys.argv[1] == '--help':
   print ''
   print 'Functions:'
   print '  string execute(string functionName, string funcArgs)'
+  print '  string executeBinary(string functionName, string funcArgs)'
   print ''
   sys.exit(0)
 
@@ -77,6 +78,12 @@ if cmd == 'execute':
     print 'execute requires 2 args'
     sys.exit(1)
   pp.pprint(client.execute(args[0],args[1],))
+
+elif cmd == 'executeBinary':
+  if len(args) != 2:
+    print 'executeBinary requires 2 args'
+    sys.exit(1)
+  pp.pprint(client.executeBinary(args[0],args[1],))
 
 else:
   print 'Unrecognized method %s' % cmd

--- a/src/py/storm/DistributedRPC.py
+++ b/src/py/storm/DistributedRPC.py
@@ -24,6 +24,14 @@ class Iface:
     """
     pass
 
+  def executeBinary(self, functionName, funcArgs):
+    """
+    Parameters:
+     - functionName
+     - funcArgs
+    """
+    pass
+
 
 class Client(Iface):
   def __init__(self, iprot, oprot=None):
@@ -66,12 +74,47 @@ class Client(Iface):
       raise result.e
     raise TApplicationException(TApplicationException.MISSING_RESULT, "execute failed: unknown result");
 
+  def executeBinary(self, functionName, funcArgs):
+    """
+    Parameters:
+     - functionName
+     - funcArgs
+    """
+    self.send_executeBinary(functionName, funcArgs)
+    return self.recv_executeBinary()
+
+  def send_executeBinary(self, functionName, funcArgs):
+    self._oprot.writeMessageBegin('executeBinary', TMessageType.CALL, self._seqid)
+    args = executeBinary_args()
+    args.functionName = functionName
+    args.funcArgs = funcArgs
+    args.write(self._oprot)
+    self._oprot.writeMessageEnd()
+    self._oprot.trans.flush()
+
+  def recv_executeBinary(self, ):
+    (fname, mtype, rseqid) = self._iprot.readMessageBegin()
+    if mtype == TMessageType.EXCEPTION:
+      x = TApplicationException()
+      x.read(self._iprot)
+      self._iprot.readMessageEnd()
+      raise x
+    result = executeBinary_result()
+    result.read(self._iprot)
+    self._iprot.readMessageEnd()
+    if result.success is not None:
+      return result.success
+    if result.e is not None:
+      raise result.e
+    raise TApplicationException(TApplicationException.MISSING_RESULT, "executeBinary failed: unknown result");
+
 
 class Processor(Iface, TProcessor):
   def __init__(self, handler):
     self._handler = handler
     self._processMap = {}
     self._processMap["execute"] = Processor.process_execute
+    self._processMap["executeBinary"] = Processor.process_executeBinary
 
   def process(self, iprot, oprot):
     (name, type, seqid) = iprot.readMessageBegin()
@@ -98,6 +141,20 @@ class Processor(Iface, TProcessor):
     except DRPCExecutionException, e:
       result.e = e
     oprot.writeMessageBegin("execute", TMessageType.REPLY, seqid)
+    result.write(oprot)
+    oprot.writeMessageEnd()
+    oprot.trans.flush()
+
+  def process_executeBinary(self, seqid, iprot, oprot):
+    args = executeBinary_args()
+    args.read(iprot)
+    iprot.readMessageEnd()
+    result = executeBinary_result()
+    try:
+      result.success = self._handler.executeBinary(args.functionName, args.funcArgs)
+    except DRPCExecutionException, e:
+      result.e = e
+    oprot.writeMessageBegin("executeBinary", TMessageType.REPLY, seqid)
     result.write(oprot)
     oprot.writeMessageEnd()
     oprot.trans.flush()
@@ -226,6 +283,150 @@ class execute_result:
     if self.success is not None:
       oprot.writeFieldBegin('success', TType.STRING, 0)
       oprot.writeString(self.success.encode('utf-8'))
+      oprot.writeFieldEnd()
+    if self.e is not None:
+      oprot.writeFieldBegin('e', TType.STRUCT, 1)
+      self.e.write(oprot)
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class executeBinary_args:
+  """
+  Attributes:
+   - functionName
+   - funcArgs
+  """
+
+  thrift_spec = (
+    None, # 0
+    (1, TType.STRING, 'functionName', None, None, ), # 1
+    (2, TType.STRING, 'funcArgs', None, None, ), # 2
+  )
+
+  def __init__(self, functionName=None, funcArgs=None,):
+    self.functionName = functionName
+    self.funcArgs = funcArgs
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 1:
+        if ftype == TType.STRING:
+          self.functionName = iprot.readString().decode('utf-8')
+        else:
+          iprot.skip(ftype)
+      elif fid == 2:
+        if ftype == TType.STRING:
+          self.funcArgs = iprot.readString().decode('utf-8')
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('executeBinary_args')
+    if self.functionName is not None:
+      oprot.writeFieldBegin('functionName', TType.STRING, 1)
+      oprot.writeString(self.functionName.encode('utf-8'))
+      oprot.writeFieldEnd()
+    if self.funcArgs is not None:
+      oprot.writeFieldBegin('funcArgs', TType.STRING, 2)
+      oprot.writeString(self.funcArgs.encode('utf-8'))
+      oprot.writeFieldEnd()
+    oprot.writeFieldStop()
+    oprot.writeStructEnd()
+
+  def validate(self):
+    return
+
+
+  def __repr__(self):
+    L = ['%s=%r' % (key, value)
+      for key, value in self.__dict__.iteritems()]
+    return '%s(%s)' % (self.__class__.__name__, ', '.join(L))
+
+  def __eq__(self, other):
+    return isinstance(other, self.__class__) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not (self == other)
+
+class executeBinary_result:
+  """
+  Attributes:
+   - success
+   - e
+  """
+
+  thrift_spec = (
+    (0, TType.STRING, 'success', None, None, ), # 0
+    (1, TType.STRUCT, 'e', (DRPCExecutionException, DRPCExecutionException.thrift_spec), None, ), # 1
+  )
+
+  def __init__(self, success=None, e=None,):
+    self.success = success
+    self.e = e
+
+  def read(self, iprot):
+    if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
+      fastbinary.decode_binary(self, iprot.trans, (self.__class__, self.thrift_spec))
+      return
+    iprot.readStructBegin()
+    while True:
+      (fname, ftype, fid) = iprot.readFieldBegin()
+      if ftype == TType.STOP:
+        break
+      if fid == 0:
+        if ftype == TType.STRING:
+          self.success = iprot.readString();
+        else:
+          iprot.skip(ftype)
+      elif fid == 1:
+        if ftype == TType.STRUCT:
+          self.e = DRPCExecutionException()
+          self.e.read(iprot)
+        else:
+          iprot.skip(ftype)
+      else:
+        iprot.skip(ftype)
+      iprot.readFieldEnd()
+    iprot.readStructEnd()
+
+  def write(self, oprot):
+    if oprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and self.thrift_spec is not None and fastbinary is not None:
+      oprot.trans.write(fastbinary.encode_binary(self, (self.__class__, self.thrift_spec)))
+      return
+    oprot.writeStructBegin('executeBinary_result')
+    if self.success is not None:
+      oprot.writeFieldBegin('success', TType.STRING, 0)
+      oprot.writeString(self.success)
       oprot.writeFieldEnd()
     if self.e is not None:
       oprot.writeFieldBegin('e', TType.STRUCT, 1)

--- a/src/py/storm/DistributedRPCInvocations.py
+++ b/src/py/storm/DistributedRPCInvocations.py
@@ -227,7 +227,7 @@ class result_args:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.STRING:
-          self.result = iprot.readString().decode('utf-8')
+          self.result = iprot.readString();
         else:
           iprot.skip(ftype)
       else:
@@ -246,7 +246,7 @@ class result_args:
       oprot.writeFieldEnd()
     if self.result is not None:
       oprot.writeFieldBegin('result', TType.STRING, 2)
-      oprot.writeString(self.result.encode('utf-8'))
+      oprot.writeString(self.result)
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()

--- a/src/storm.thrift
+++ b/src/storm.thrift
@@ -224,10 +224,11 @@ exception DRPCExecutionException {
 
 service DistributedRPC {
   string execute(1: string functionName, 2: string funcArgs) throws (1: DRPCExecutionException e);
+  binary executeBinary(1: string functionName, 2: string funcArgs) throws (1: DRPCExecutionException e);
 }
 
 service DistributedRPCInvocations {
-  void result(1: string id, 2: string result);
+  void result(1: string id, 2: binary result);
   DRPCRequest fetchRequest(1: string functionName);
   void failRequest(1: string id);  
 }


### PR DESCRIPTION
executeBinary returns java.nio.ByteBuffer, legacy "execute" method now
converts from ByteBuffer to String using default encoding
