### PR TITLE
Update to Curator 1.1.3/ZooKeeper 3.4.x

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [storm/libthrift7 "0.7.0"]
                  [clj-time "0.4.1"]
                  [log4j/log4j "1.2.16"]
-                 [com.netflix.curator/curator-framework "1.0.1"]
+                 [com.netflix.curator/curator-framework "1.1.3"]
                  [backtype/jzmq "2.1.0"]
                  [com.googlecode.json-simple/json-simple "1.1"]
                  [com.googlecode/kryo "1.04"]

--- a/src/clj/backtype/storm/zookeeper.clj
+++ b/src/clj/backtype/storm/zookeeper.clj
@@ -6,7 +6,7 @@
             ZooDefs ZooDefs$Ids CreateMode WatchedEvent Watcher$Event Watcher$Event$KeeperState
             Watcher$Event$EventType KeeperException$NodeExistsException])
   (:import [org.apache.zookeeper.data Stat])
-  (:import [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxn$Factory])
+  (:import [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxnFactory])
   (:import [java.net InetSocketAddress BindException])
   (:import [java.io File])
   (:import [backtype.storm.utils Utils])
@@ -132,7 +132,7 @@
   (let [localfile (File. localdir)
         zk (ZooKeeperServer. localfile localfile 2000)
         [retport factory] (loop [retport (if port port 2000)]
-                            (if-let [factory-tmp (try-cause (NIOServerCnxn$Factory. (InetSocketAddress. retport))
+                            (if-let [factory-tmp (try-cause (NIOServerCnxnFactory/createFactory retport 60) ;; 60 is the default maxclientcnxns
                                               (catch BindException e
                                                 (when (> (inc retport) (if port port 65535))
                                                   (throw (RuntimeException. "No port is available to launch an inprocess zookeeper.")))))]


### PR DESCRIPTION
Replaces the Curator 1.0.x series dependency with 1.1.3, which introduces ZooKeeper 3.4.2. Changed the in-process ZK server to use the new NIOServerCnxnFactory in ZooKeeper 3.4.x.

ZK 3.4.x clients are compatible with ZK 3.3.x ensembles.

This change makes Storm compatible with HBase 0.92, which requires the new ZK 3.4 API.
