### PR TITLE
Use exec instead of forked child process for JVM

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -82,12 +82,15 @@ def print_remoteconfvalue(name):
     """
     print name + ": " + confvalue(name, [STORM_DIR + "/conf"])
 
-def exec_storm_class(klass, jvmtype="-server", childopts="", extrajars=[], args=[]):
-    nativepath = confvalue("java.library.path", extrajars)
-    args_str = " ".join(map(lambda s: "\"" + s + "\"", args))
-    command = "java " + jvmtype + " -Dstorm.home=" + STORM_DIR + " " + get_config_opts() + " -Djava.library.path=" + nativepath + " " + childopts + " -cp " + get_classpath(extrajars) + " " + klass + " " + args_str
-    print "Running: " + command    
-    os.system(command)
+def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]):
+    all_args = [
+        "java", jvmtype, get_config_opts(),
+        "-Dstorm.home=" + STORM_DIR, 
+        "-Djava.library.path=" + confvalue("java.library.path", extrajars),
+        "-cp", get_classpath(extrajars),
+    ] + jvmopts + [klass] + args
+    print "Running: " + " ".join(all_args)
+    os.execvp("java", all_args)
 
 def jar(jarfile, klass, *args):
     """Syntax: [storm jar topology-jar-path class ...]
@@ -103,7 +106,7 @@ def jar(jarfile, klass, *args):
         jvmtype="-client",
         extrajars=[jarfile, CONF_DIR, STORM_DIR + "/bin"],
         args=args,
-        childopts="-Dstorm.jar=" + jarfile)
+        jvmopts=["-Dstorm.jar=" + jarfile])
 
 def kill(*args):
     """Syntax: [storm kill topology-name [-w wait-time-secs]]
@@ -208,12 +211,15 @@ def nimbus(klass="backtype.storm.daemon.nimbus"):
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    childopts = confvalue("nimbus.childopts", cppaths) + " -Dlogfile.name=nimbus.log -Dlog4j.configuration=storm.log.properties"
+    jvmopts = confvalue("nimbus.childopts", cppaths).split() + [
+        "-Dlogfile.name=nimbus.log",
+        "-Dlog4j.configuration=storm.log.properties",
+    ]
     exec_storm_class(
         klass, 
         jvmtype="-server", 
         extrajars=cppaths, 
-        childopts=childopts)
+        jvmopts=jvmopts)
 
 def supervisor(klass="backtype.storm.daemon.supervisor"):
     """Syntax: [storm supervisor]
@@ -225,12 +231,15 @@ def supervisor(klass="backtype.storm.daemon.supervisor"):
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    childopts = confvalue("supervisor.childopts", cppaths) + " -Dlogfile.name=supervisor.log -Dlog4j.configuration=storm.log.properties"
+    jvmopts = confvalue("supervisor.childopts", cppaths).split() + [
+        "-Dlogfile.name=supervisor.log",
+        "-Dlog4j.configuration=storm.log.properties",
+    ]
     exec_storm_class(
         klass, 
         jvmtype="-server", 
         extrajars=cppaths, 
-        childopts=childopts)
+        jvmopts=jvmopts)
 
 def ui():
     """Syntax: [storm ui]
@@ -243,11 +252,14 @@ def ui():
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    childopts = confvalue("ui.childopts", cppaths) + " -Dlogfile.name=ui.log -Dlog4j.configuration=storm.log.properties"
+    jvmopts = confvalue("ui.childopts", cppaths).split() + [
+        "-Dlogfile.name=ui.log",
+        "-Dlog4j.configuration=storm.log.properties",
+    ]
     exec_storm_class(
         "backtype.storm.ui.core", 
         jvmtype="-server", 
-        childopts=childopts, 
+        jvmopts=jvmopts, 
         extrajars=[STORM_DIR + "/log4j", STORM_DIR, STORM_DIR + "/conf"])
 
 def drpc():
@@ -259,11 +271,11 @@ def drpc():
     See Distributed RPC for more information.
     (https://github.com/nathanmarz/storm/wiki/Distributed-RPC)
     """
-    childopts = "-Xmx768m -Dlogfile.name=drpc.log -Dlog4j.configuration=storm.log.properties"
+    jvmopts = ["-Xmx768m", "-Dlogfile.name=drpc.log", "-Dlog4j.configuration=storm.log.properties"]
     exec_storm_class(
         "backtype.storm.daemon.drpc", 
         jvmtype="-server", 
-        childopts=childopts, 
+        jvmopts=jvmopts, 
         extrajars=[STORM_DIR + "/log4j", STORM_DIR + "/conf"])
 
 def dev_zookeeper():

--- a/bin/storm
+++ b/bin/storm
@@ -5,6 +5,7 @@ import sys
 import random
 import subprocess as sub
 import getopt
+import re
 
 def identity(x):
     return x
@@ -81,6 +82,25 @@ def print_remoteconfvalue(name):
     This command must be run on a cluster machine.
     """
     print name + ": " + confvalue(name, [STORM_DIR + "/conf"])
+
+def parse_args(string):
+    """Takes a string of whitespace-separated tokens and parses it into a list.
+    Whitespace inside tokens may be quoted with single quotes, double quotes or
+    backslash (similar to command-line arguments in bash).
+
+    >>> parse_args(r'''"a a" 'b b' c\ c "d'd" 'e"e' 'f\'f' "g\"g" "i""i" 'j''j' k" "k l' l' mm n\\n''')
+    ['a a', 'b b', 'c c', "d'd", 'e"e', "f'f", 'g"g', 'ii', 'jj', 'k k', 'l l', 'mm', r'n\n']
+    """
+    re_split = re.compile(r'''((?:
+        [^\s"'\\] |
+        "(?: [^"\\] | \\.)*" |
+        '(?: [^'\\] | \\.)*' |
+        \\.
+    )+)''', re.VERBOSE)
+    args = re_split.split(string)[1::2]
+    args = [re.compile(r'"((?:[^"\\]|\\.)*)"').sub('\\1', x) for x in args]
+    args = [re.compile(r"'((?:[^'\\]|\\.)*)'").sub('\\1', x) for x in args]
+    return [re.compile(r'\\(.)').sub('\\1', x) for x in args]
 
 def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]):
     all_args = [
@@ -211,7 +231,7 @@ def nimbus(klass="backtype.storm.daemon.nimbus"):
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    jvmopts = confvalue("nimbus.childopts", cppaths).split() + [
+    jvmopts = parse_args(confvalue("nimbus.childopts", cppaths)) + [
         "-Dlogfile.name=nimbus.log",
         "-Dlog4j.configuration=storm.log.properties",
     ]
@@ -231,7 +251,7 @@ def supervisor(klass="backtype.storm.daemon.supervisor"):
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    jvmopts = confvalue("supervisor.childopts", cppaths).split() + [
+    jvmopts = parse_args(confvalue("supervisor.childopts", cppaths)) + [
         "-Dlogfile.name=supervisor.log",
         "-Dlog4j.configuration=storm.log.properties",
     ]
@@ -252,7 +272,7 @@ def ui():
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
     cppaths = [STORM_DIR + "/log4j", STORM_DIR + "/conf"]
-    jvmopts = confvalue("ui.childopts", cppaths).split() + [
+    jvmopts = parse_args(confvalue("ui.childopts", cppaths)) + [
         "-Dlogfile.name=ui.log",
         "-Dlog4j.configuration=storm.log.properties",
     ]

--- a/bin/storm
+++ b/bin/storm
@@ -62,6 +62,7 @@ def confvalue(name, extrapaths):
         tokens = line.split(" ")
         if tokens[0] == "VALUE:":
             return " ".join(tokens[1:])
+    return ""
 
 def print_localconfvalue(name):
     """Syntax: [storm localconfvalue conf-name]
@@ -97,7 +98,7 @@ def parse_args(string):
         '(?: [^'\\] | \\.)*' |
         \\.
     )+)''', re.VERBOSE)
-    args = re_split.split(string or '')[1::2]
+    args = re_split.split(string)[1::2]
     args = [re.compile(r'"((?:[^"\\]|\\.)*)"').sub('\\1', x) for x in args]
     args = [re.compile(r"'((?:[^'\\]|\\.)*)'").sub('\\1', x) for x in args]
     return [re.compile(r'\\(.)').sub('\\1', x) for x in args]

--- a/bin/storm
+++ b/bin/storm
@@ -97,7 +97,7 @@ def parse_args(string):
         '(?: [^'\\] | \\.)*' |
         \\.
     )+)''', re.VERBOSE)
-    args = re_split.split(string)[1::2]
+    args = re_split.split(string or '')[1::2]
     args = [re.compile(r'"((?:[^"\\]|\\.)*)"').sub('\\1', x) for x in args]
     args = [re.compile(r"'((?:[^'\\]|\\.)*)'").sub('\\1', x) for x in args]
     return [re.compile(r'\\(.)').sub('\\1', x) for x in args]

--- a/bin/storm
+++ b/bin/storm
@@ -102,7 +102,7 @@ def parse_args(string):
     args = [re.compile(r"'((?:[^'\\]|\\.)*)'").sub('\\1', x) for x in args]
     return [re.compile(r'\\(.)').sub('\\1', x) for x in args]
 
-def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]):
+def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[], fork=False):
     all_args = [
         "java", jvmtype, get_config_opts(),
         "-Dstorm.home=" + STORM_DIR, 
@@ -110,7 +110,10 @@ def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]
         "-cp", get_classpath(extrajars),
     ] + jvmopts + [klass] + args
     print "Running: " + " ".join(all_args)
-    os.execvp("java", all_args)
+    if fork:
+        os.spawnvp(os.P_WAIT, "java", all_args)
+    else:
+        os.execvp("java", all_args) # replaces the current process and never returns
 
 def jar(jarfile, klass, *args):
     """Syntax: [storm jar topology-jar-path class ...]
@@ -209,7 +212,8 @@ def shell(resourcesdir, command, *args):
         "backtype.storm.command.shell_submission", 
         args=runnerargs, 
         jvmtype="-client", 
-        extrajars=[CONF_DIR])
+        extrajars=[CONF_DIR],
+        fork=True)
     os.system("rm " + tmpjarpath)
 
 def repl():

--- a/bin/storm
+++ b/bin/storm
@@ -108,7 +108,7 @@ def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[]
         "-Dstorm.home=" + STORM_DIR, 
         "-Djava.library.path=" + confvalue("java.library.path", extrajars),
         "-cp", get_classpath(extrajars),
-    ] + jvmopts + [klass] + args
+    ] + jvmopts + [klass] + list(args)
     print "Running: " + " ".join(all_args)
     if fork:
         os.spawnvp(os.P_WAIT, "java", all_args)

--- a/bin/storm
+++ b/bin/storm
@@ -84,7 +84,7 @@ def print_remoteconfvalue(name):
     print name + ": " + confvalue(name, [STORM_DIR + "/conf"])
 
 def parse_args(string):
-    """Takes a string of whitespace-separated tokens and parses it into a list.
+    r"""Takes a string of whitespace-separated tokens and parses it into a list.
     Whitespace inside tokens may be quoted with single quotes, double quotes or
     backslash (similar to command-line arguments in bash).
 


### PR DESCRIPTION
Using os.system() for creating the JVM forks a child of the Python
process. This makes it difficult for process managers like daemontools
or runit to kill/restart the process at admins' command: the process
manager tracks the PID of the Python process instead of that of the JVM;
and terminating the Python process unfortunately doesn't kill its JVM
child.

Some process managers let you configure the number of times the service
forks, or try to detect forks, but it's a bit of a rabbit-hole. Better
to make the service not fork in the first place.

For that reason I've replaced the call to os.system() with os.execvp(),
which replaces the Python process with the JVM, and thus lets the
process manager track the right PID.

os.execvp() requires that you give command-line arguments as an array of
strings, rather than one long whitespace-separated string, so I had to
change some of the surrounding code accordingly. Note this has the
pleasant side-effect that Storm should now also run if you install it in
a directory that has spaces in its path name.
