### PR TITLE
0.7.2

### DIFF
--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -32,7 +32,7 @@
                             ))]
     (into {} (for [[port task-ids] port-tasks]
                ;; need to cast to int b/c it might be a long (due to how yaml parses things)
-               [(Integer. port) (LocalAssignment. storm-id task-ids)]
+               [(Integer. port) (LocalAssignment. storm-id (doall task-ids))]
                ))
     ))
 


### PR DESCRIPTION
This patch forces supervisor realize task-ids that it will flush into the local state file.  Without the realization, supervisor can stop due to ClassNotFoundException in some rare cases.
