### PR TITLE
fix Cluster.getNeedsSchedulingExecutorToComponents & some cleanup

### DIFF
--- a/src/jvm/backtype/storm/scheduler/Cluster.java
+++ b/src/jvm/backtype/storm/scheduler/Cluster.java
@@ -8,8 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import backtype.storm.Config;
-
 public class Cluster {
 
     /**
@@ -86,8 +84,9 @@ public class Cluster {
      * @return
      */
     public Map<ExecutorDetails, String> getNeedsSchedulingExecutorToComponents(TopologyDetails topology) {
-        Collection<ExecutorDetails> allExecutors = topology.getExecutors();
-
+        Collection<ExecutorDetails> allExecutors = new ArrayList<ExecutorDetails>();
+        allExecutors.addAll(topology.getExecutors());
+        
         SchedulerAssignment assignment = this.assignments.get(topology.getId());
         if (assignment != null) {
             Collection<ExecutorDetails> assignedExecutors = assignment.getExecutors();
@@ -181,17 +180,15 @@ public class Cluster {
             return new ArrayList<ExecutorDetails>(0);
         }
 
-        Collection<ExecutorDetails> allExecutors = topology.getExecutors();
+        List<ExecutorDetails> ret = new ArrayList<ExecutorDetails>();
+        ret.addAll(topology.getExecutors());
+        
         SchedulerAssignment assignment = this.getAssignmentById(topology.getId());
-
         if (assignment != null) {
             Set<ExecutorDetails> assignedExecutors = assignment.getExecutors();
-            allExecutors.removeAll(assignedExecutors);
+            ret.removeAll(assignedExecutors);
         }
-
-        List<ExecutorDetails> ret = new ArrayList<ExecutorDetails>(allExecutors.size());
-        ret.addAll(allExecutors);
-
+        
         return ret;
     }
 
@@ -352,15 +349,5 @@ public class Cluster {
      */
     public Map<String, SupervisorDetails> getSupervisors() {
         return this.supervisors;
-    }
-    
-    private boolean isExecutorAssigned(ExecutorDetails executor) {
-        for (SchedulerAssignment assignment : this.assignments.values()) {
-            if (assignment.isExecutorAssigned(executor)) {
-                return true;
-            }
-        }
-        
-        return false;
     }
 }

--- a/src/jvm/backtype/storm/scheduler/ExecutorDetails.java
+++ b/src/jvm/backtype/storm/scheduler/ExecutorDetails.java
@@ -1,19 +1,19 @@
 package backtype.storm.scheduler;
 
 public class ExecutorDetails {
-    Integer startTask;
-    Integer endTask;
+    int startTask;
+    int endTask;
 
-    public ExecutorDetails(Integer startTask, Integer endTask){
+    public ExecutorDetails(int startTask, int endTask){
         this.startTask = startTask;
         this.endTask = endTask;
     }
 
-    public Integer getStartTask() {
+    public int getStartTask() {
         return startTask;
     }
 
-    public Integer getEndTask() {
+    public int getEndTask() {
         return endTask;
     }
 
@@ -28,5 +28,10 @@ public class ExecutorDetails {
     
     public int hashCode() {
         return this.startTask + 13 * this.endTask;
+    }
+    
+    @Override
+    public String toString() {
+    	return "[" + this.startTask + ", " + this.endTask + "]";
     }
 }

--- a/src/jvm/backtype/storm/scheduler/WorkerSlot.java
+++ b/src/jvm/backtype/storm/scheduler/WorkerSlot.java
@@ -27,4 +27,9 @@ public class WorkerSlot {
         WorkerSlot other = (WorkerSlot) o;
         return this.port == other.port && this.nodeId.equals(other.nodeId);
     }    
+    
+    @Override
+    public String toString() {
+    	return this.nodeId + ":" + this.port;
+    }
 }


### PR DESCRIPTION
Currently Cluster.getNeedsSchedulingExecutorToComponents returns all the executors rather than just the executors needs scheduling. It is fixed by change the type of ExecutorDetails.startTask/endTask from Integer to int, because `new Integer(10) != new Integer(10)`. Also done some cleanup.
