### PR TITLE
Update Curator Version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [storm/libthrift7 "0.7.0"]
                  [clj-time "0.4.1"]
                  [log4j/log4j "1.2.16"]
-                 [com.netflix.curator/curator-framework "1.0.1"]
+                 [com.netflix.curator/curator-framework "1.0.16"]
                  [backtype/jzmq "2.1.0"]
                  [com.googlecode.json-simple/json-simple "1.1"]
                  [compojure "0.6.4"]


### PR DESCRIPTION
This is a simple bump to the latest version of netflix/curator that maintains compatibility with zookeeper 3.3.x.

**Notes related to upgrading to curator 1.1.x/zookeeper 3.4.x:**
- zookeeper 3.4.x uses Netty internally rather than NIO directly - this will impact the method for creating an in-process zookeeper in "zookeeper.clj" (mk-inprocess-zookeeper).
- The above issue can possibly be addressed by using some of the curator-test classes for creating in-proc zookeeper servers.
- Looks like there are some authentication options in the latest version of curator/zookeeper.

I tried a bump to curator 1.1.16/zookeeper 3.4.5 by reusing curator test classes (modified the the mk-inprocess-zookeeper method). It made the tests run excruciatingly slow with a bunch of stacktraces. Tests passed, but I didn't trust the result. I'll continue investigating at some point.
