### PR TITLE
Reverting the generics tightening because nested generics in java are limited

### DIFF
--- a/src/jvm/storm/trident/state/map/OpaqueMap.java
+++ b/src/jvm/storm/trident/state/map/OpaqueMap.java
@@ -8,24 +8,24 @@ import java.util.List;
 
 
 public class OpaqueMap<T> implements MapState<T> {
-    public static <T> MapState<T> build(IBackingMap<OpaqueValue<T>> backing) {
+    public static <T> MapState<T> build(IBackingMap<OpaqueValue> backing) {
         return new CachedBatchReadsMap<T>(new OpaqueMap<T>(backing));
     }
     
-    IBackingMap<OpaqueValue<T>> _backing;
+    IBackingMap<OpaqueValue> _backing;
     Long _currTx;
     
-    protected OpaqueMap(IBackingMap<OpaqueValue<T>> backing) {
+    protected OpaqueMap(IBackingMap<OpaqueValue> backing) {
         _backing = backing;
     }
     
     @Override
     public List<T> multiGet(List<List<Object>> keys) {
-        List<OpaqueValue<T>> curr = _backing.multiGet(keys);
+        List<OpaqueValue> curr = _backing.multiGet(keys);
         List<T> ret = new ArrayList<T>(curr.size());
-        for(OpaqueValue<T> val: curr) {
+        for(OpaqueValue val: curr) {
             if(val!=null) {
-                ret.add(val.get(_currTx));
+                ret.add((T) val.get(_currTx));
             } else {
                 ret.add(null);
             }
@@ -35,8 +35,8 @@ public class OpaqueMap<T> implements MapState<T> {
 
     @Override
     public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
-        List<OpaqueValue<T>> curr = _backing.multiGet(keys);
-        List<OpaqueValue<T>> newVals = new ArrayList<OpaqueValue<T>>(curr.size());
+        List<OpaqueValue> curr = _backing.multiGet(keys);
+        List<OpaqueValue> newVals = new ArrayList<OpaqueValue>(curr.size());
         List<T> ret = new ArrayList<T>();
         for(int i=0; i<curr.size(); i++) {
             OpaqueValue<T> val = curr.get(i);

--- a/src/jvm/storm/trident/state/map/TransactionalMap.java
+++ b/src/jvm/storm/trident/state/map/TransactionalMap.java
@@ -8,24 +8,24 @@ import java.util.List;
 
 
 public class TransactionalMap<T> implements MapState<T> {
-    public static <T> MapState<T> build(IBackingMap<TransactionalValue<T>> backing) {
+    public static <T> MapState<T> build(IBackingMap<TransactionalValue> backing) {
         return new CachedBatchReadsMap<T>(new TransactionalMap<T>(backing));
     }
     
-    IBackingMap<TransactionalValue<T>> _backing;
+    IBackingMap<TransactionalValue> _backing;
     Long _currTx;
     
-    protected TransactionalMap(IBackingMap<TransactionalValue<T>> backing) {
+    protected TransactionalMap(IBackingMap<TransactionalValue> backing) {
         _backing = backing;
     }
     
     @Override
     public List<T> multiGet(List<List<Object>> keys) {
-        List<TransactionalValue<T>> vals = _backing.multiGet(keys);
+        List<TransactionalValue> vals = _backing.multiGet(keys);
         List<T> ret = new ArrayList<T>(vals.size());
-        for(TransactionalValue<T> v: vals) {
+        for(TransactionalValue v: vals) {
             if(v!=null) {
-                ret.add(v.getVal());
+                ret.add((T) v.getVal());
             } else {
                 ret.add(null);
             }
@@ -35,8 +35,8 @@ public class TransactionalMap<T> implements MapState<T> {
 
     @Override
     public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
-        List<TransactionalValue<T>> curr = _backing.multiGet(keys);
-        List<TransactionalValue<T>> newVals = new ArrayList<TransactionalValue<T>>(curr.size());
+        List<TransactionalValue> curr = _backing.multiGet(keys);
+        List<TransactionalValue> newVals = new ArrayList<TransactionalValue>(curr.size());
         List<T> ret = new ArrayList<T>();
         for(int i=0; i<curr.size(); i++) {
             TransactionalValue<T> val = curr.get(i);
@@ -60,7 +60,7 @@ public class TransactionalMap<T> implements MapState<T> {
 
     @Override
     public void multiPut(List<List<Object>> keys, List<T> vals) {
-        List<TransactionalValue<T>> newVals = new ArrayList<TransactionalValue<T>>(vals.size());
+        List<TransactionalValue> newVals = new ArrayList<TransactionalValue>(vals.size());
         for(T val: vals) {
             newVals.add(new TransactionalValue<T>(_currTx, val));
         }


### PR DESCRIPTION
Sorry, reverting partially my change.

I'm currently busy with implementing a MongoDB State and It's just impossible to have something like:

``` java
state = new MongoState<TransactionalValue<S>>(template, TransactionalValue<S>.class);
cachedMap = new CachedMap<TransactionalValue<S>>(state, opts.localCacheSize);
return TransactionalMap.build(cachedMap);
```

And i need to pass the entityClass as argument because i need it for the mongo template to automaticly serialize / deserialize the pojo. 

``` java
state = new MongoState<TransactionalValue>(template, TransactionalValue.class);
cachedMap = new CachedMap<TransactionalValue>(state, opts.localCacheSize);
return TransactionalMap.<S>build(cachedMap);
```

it will be then
