### PR TITLE
Change ShellSpout and ShellBolt so that returning task IDs to the spout or bolt is optional

### DIFF
--- a/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -95,7 +95,10 @@ public class ShellSpout implements ISpout {
                     Object messageId = (Object) action.get("id");
                     if (task == null) {
                         List<Integer> outtasks = _collector.emit(stream, tuple, messageId);
-                        _process.writeMessage(outtasks);
+                        Object need_task_ids = action.get("need_task_ids");
+                        if (need_task_ids == null || ((Boolean) need_task_ids).booleanValue()) {
+                            _process.writeMessage(outtasks);
+                        }
                     } else {
                         _collector.emitDirect((int)task.longValue(), stream, tuple, messageId);
                     }

--- a/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/src/jvm/backtype/storm/task/ShellBolt.java
@@ -198,7 +198,10 @@ public class ShellBolt implements IBolt {
         }
         if(task==null) {
             List<Integer> outtasks = _collector.emit(stream, anchors, tuple);
-            _pendingWrites.put(outtasks);
+            Object need_task_ids = action.get("need_task_ids");
+            if (need_task_ids == null || ((Boolean) need_task_ids).booleanValue()) {
+                _pendingWrites.put(outtasks);
+            }
         } else {
             _collector.emitDirect((int)task.longValue(), stream, anchors, tuple);
         }


### PR DESCRIPTION
After doing some profiling of a real-life topology implemented in Python, I found that a lot of time was spent communicating between ShellSpout or ShellBolt and the actual spout or bolt code in Python. After making the attached changes to ShellSpout and ShellBolt, and making a couple of changes to storm.py, the communication time was 2.5x faster.

The primary change to storm.py was adding an optional "need_task_ids" parameter to emitSpout() and emitBolt().

I followed this up by adding new storm.py functions emitManySpout() and emitManyBolt(). Using these functions to batch up the emission of tuples improved communication performance about another 25%.
