### PR TITLE
add 'contains' method to Fields and Tuple.

### DIFF
--- a/src/jvm/backtype/storm/tuple/Fields.java
+++ b/src/jvm/backtype/storm/tuple/Fields.java
@@ -52,12 +52,22 @@ public class Fields implements Iterable<String>, Serializable {
         return _fields.iterator();
     }
     
+    /**
+     * Returns the position of the specified field.
+     */
     public int fieldIndex(String field) {
         Integer ret = _index.get(field);
         if(ret==null) {
             throw new IllegalArgumentException(field + " does not exist");
         }
         return ret;
+    }
+    
+    /**
+     * Returns true if this contains the specified name of the field.
+     */
+    public boolean contains(String field) {
+        return _index.containsKey(field);
     }
     
     private void index() {

--- a/src/jvm/backtype/storm/tuple/Tuple.java
+++ b/src/jvm/backtype/storm/tuple/Tuple.java
@@ -21,7 +21,15 @@ public interface Tuple {
      */
     public int size();
     
+    /**
+     * Returns the position of the specified field in this tuple.
+     */
     public int fieldIndex(String field);
+    
+    /**
+     * Returns true if this tuple contains the specified name of the field.
+     */
+    public boolean contains(String field);
     
     /**
      * Gets the field at position i in the tuple. Returns object since tuples are dynamically typed.
@@ -139,5 +147,8 @@ public interface Tuple {
      */
     public String getSourceStreamId();
     
+    /**
+     * Gets the message id that associated with this tuple.
+     */
     public MessageId getMessageId();
 }

--- a/src/jvm/backtype/storm/tuple/TupleImpl.java
+++ b/src/jvm/backtype/storm/tuple/TupleImpl.java
@@ -74,6 +74,10 @@ public class TupleImpl extends IndifferentAccessMap implements Seqable, Indexed,
         return getFields().fieldIndex(field);
     }
     
+    public boolean contains(String field) {
+        return getFields().contains(field);
+    }
+    
     public Object getValue(int i) {
         return values.get(i);
     }

--- a/test/clj/backtype/storm/fields_test.clj
+++ b/test/clj/backtype/storm/fields_test.clj
@@ -26,6 +26,10 @@
         (is (= (.fieldIndex fields "foo") 0))
         (is (= (.fieldIndex fields "bar") 1))
         (is (thrown? IllegalArgumentException (.fieldIndex fields "baz"))))
+      (testing ".contains"
+        (is (= (.contains fields "foo") true))
+        (is (= (.contains fields "bar") true))
+        (is (= (.contains fields "baz") false)))
       (testing ".toList"
         (is (instance? List (.toList fields)))
         (is (= (count (.toList fields)) 2))


### PR DESCRIPTION
Adds `boolean contains(String field)` method to `Fields` and `Tuple` to check whether a tuple contains a specified field or not as in 0.7.*. Please see also #317.
