### PR TITLE
log topology submission issues

### DIFF
--- a/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/src/clj/backtype/storm/daemon/nimbus.clj
@@ -871,38 +871,41 @@
     (reify Nimbus$Iface
       (^void submitTopology
         [this ^String storm-name ^String uploadedJarLocation ^String serializedConf ^StormTopology topology]
-        (validate-topology-name! storm-name)
-        (check-storm-active! nimbus storm-name false)
-        (.validate ^backtype.storm.nimbus.ITopologyValidator (:validator nimbus)
-              storm-name
-              (from-json serializedConf)
-              topology)
-        (swap! (:submitted-count nimbus) inc)
-        (let [storm-id (str storm-name "-" @(:submitted-count nimbus) "-" (current-time-secs))
-              storm-conf (normalize-conf
-                          conf
-                          (-> serializedConf
-                              from-json
-                              (assoc STORM-ID storm-id)
-                              (assoc TOPOLOGY-NAME storm-name))
-                          topology)
-              total-storm-conf (merge conf storm-conf)
-              topology (normalize-topology total-storm-conf topology)
-              topology (if (total-storm-conf TOPOLOGY-OPTIMIZE)
-                         (optimize-topology topology)
-                         topology)
-              storm-cluster-state (:storm-cluster-state nimbus)]
-          (system-topology! total-storm-conf topology) ;; this validates the structure of the topology
-          (log-message "Received topology submission for " storm-name " with conf " storm-conf)
-          ;; lock protects against multiple topologies being submitted at once and
-          ;; cleanup thread killing topology in b/w assignment and starting the topology
-          (locking (:submit-lock nimbus)
-            (setup-storm-code conf storm-id uploadedJarLocation storm-conf topology)
-            (.setup-heartbeats! storm-cluster-state storm-id)
-            (start-storm nimbus storm-name storm-id)
-            (mk-assignments nimbus))
-          ))
-      
+        (try
+          (validate-topology-name! storm-name)
+          (check-storm-active! nimbus storm-name false)
+          (.validate ^backtype.storm.nimbus.ITopologyValidator (:validator nimbus)
+                     storm-name
+                     (from-json serializedConf)
+                     topology)
+          (swap! (:submitted-count nimbus) inc)
+          (let [storm-id (str storm-name "-" @(:submitted-count nimbus) "-" (current-time-secs))
+                storm-conf (normalize-conf
+                            conf
+                            (-> serializedConf
+                                from-json
+                                (assoc STORM-ID storm-id)
+                                (assoc TOPOLOGY-NAME storm-name))
+                            topology)
+                total-storm-conf (merge conf storm-conf)
+                topology (normalize-topology total-storm-conf topology)
+                topology (if (total-storm-conf TOPOLOGY-OPTIMIZE)
+                           (optimize-topology topology)
+                           topology)
+                storm-cluster-state (:storm-cluster-state nimbus)]
+            (system-topology! total-storm-conf topology) ;; this validates the structure of the topology
+            (log-message "Received topology submission for " storm-name " with conf " storm-conf)
+            ;; lock protects against multiple topologies being submitted at once and
+            ;; cleanup thread killing topology in b/w assignment and starting the topology
+            (locking (:submit-lock nimbus)
+              (setup-storm-code conf storm-id uploadedJarLocation storm-conf topology)
+              (.setup-heartbeats! storm-cluster-state storm-id)
+              (start-storm nimbus storm-name storm-id)
+              (mk-assignments nimbus)))
+
+          (catch Throwable e
+            (log-warn-error e "Topology submission exception. (topology name='" storm-name "')"))))
+
       (^void killTopology [this ^String name]
         (.killTopologyWithOpts this name (KillOptions.)))
 

--- a/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/src/clj/backtype/storm/daemon/nimbus.clj
@@ -904,7 +904,8 @@
               (mk-assignments nimbus)))
 
           (catch Throwable e
-            (log-warn-error e "Topology submission exception. (topology name='" storm-name "')"))))
+            (log-warn-error e "Topology submission exception. (topology name='" storm-name "')")
+            (throw e))))
 
       (^void killTopology [this ^String name]
         (.killTopologyWithOpts this name (KillOptions.)))

--- a/src/jvm/backtype/storm/StormSubmitter.java
+++ b/src/jvm/backtype/storm/StormSubmitter.java
@@ -58,6 +58,12 @@ public class StormSubmitter {
                 try {
                     LOG.info("Submitting topology " +  name + " in distributed mode with conf " + serConf);
                     client.getClient().submitTopology(name, submittedJar, serConf, topology);
+                } catch(InvalidTopologyException e) {
+                    LOG.warn("Topology submission exception", e);
+                    throw e;
+                } catch(AlreadyAliveException e) {
+                    LOG.warn("Topology already alive exception", e);
+                    throw e;
                 } finally {
                     client.close();
                 }


### PR DESCRIPTION
A storm user was not printing exceptions thrown by StormSubmitter, wasted a bit of time because nimbus.log had no info about it.
