### PR TITLE
Fix FileNotFoundException during cleanup

### DIFF
--- a/src/clj/backtype/storm/util.clj
+++ b/src/clj/backtype/storm/util.clj
@@ -410,7 +410,13 @@
 (defn rmr [path]
   (log-debug "Rmr path " path)
   (when (exists-file? path)
-    (FileUtils/forceDelete (File. path))))
+    ;; Somehow sometimes the file still isn't found.
+    ;; Not sure why.
+    (try
+      (FileUtils/forceDelete (File. path))
+      (catch java.io.FileNotFoundException ex
+        (log-error ex "System said " path " existed, but can't find it to "
+                   "delete. Ignoring.")))))
 
 (defn rmpath
   "Removes file or directory at the path. Not recursive. Throws exception on failure"


### PR DESCRIPTION
See issue #356

Code already checks for existence of file, but sometimes we get
FileNotFoundException anyway. Honestly not sure why, but this fixes it.
