### PR TITLE
Make UI friendly to repl development by not joining jetty thread

### DIFF
--- a/src/clj/backtype/storm/ui/core.clj
+++ b/src/clj/backtype/storm/ui/core.clj
@@ -728,5 +728,7 @@
   (handler/site main-routes)
  )
 
-(defn -main []
-  (run-jetty app {:port (Integer. (*STORM-CONF* UI-PORT))}))
+(defn start-server! [] (run-jetty app {:port (Integer. (*STORM-CONF* UI-PORT))
+                                       :join? false}))
+
+(defn -main [] (start-server!))


### PR DESCRIPTION
This lets you run the jetty server alongside the repl, which makes it easier to do development on the UI. The use of 'defonce' lets you recompile without worrying that the server gets redefined. The following commands start/stop the server from the repl:

(.start server)
(.stop server)
