### PR TITLE
Include a warning about Leiningen 2.x in docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,8 @@
+(def lein-version (System/getenv "LEIN_VERSION"))
+(if-not (re-find #"^1\..*$" lein-version)
+  (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
+    (System/exit 1)))
+
 (defproject storm "0.8.2-wip11"
   :source-path "src/clj"
   :test-path "test/clj"
@@ -36,4 +41,3 @@
   :extra-classpath-dirs ["src/ui"]
   :aot :all
 )
-


### PR DESCRIPTION
Currently "lein (uber)jar" silently fails when using lein >= 2, and "lein test" complains about missing files on the classpath.

This is a pain when you're trying to get your dev environment setup for Storm, after following every instruction to a tee, only to have nothing work. As long as Storm is incompatible with lein 2.x, a big warning should be included somewhere in the docs telling the user to use lein 1.x
