### PR TITLE
bin/build_release.sh fixed

### DIFF
--- a/bin/build_release.sh
+++ b/bin/build_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RELEASE=`head -1 project.clj | awk '{print $3}' | sed -e 's/\"//' | sed -e 's/\"//'`
+RELEASE=`cat project.clj | sed '6q;d' | awk '{print $3}' | sed -e 's/\"//' | sed -e 's/\"//'`
 
 echo Making release $RELEASE
 


### PR DESCRIPTION
fix for #374

After adding lein version check we should parse the sixth line of project.clj instead of first to take version from it.
