### PR TITLE
Use resources evenly when managing multiple topologies

### DIFF
--- a/src/clj/backtype/storm/scheduler/EvenScheduler.clj
+++ b/src/clj/backtype/storm/scheduler/EvenScheduler.clj
@@ -7,8 +7,11 @@
     :implements [backtype.storm.scheduler.IScheduler]))
 
 (defn sort-slots [all-slots]
-  (let [split-up (vals (group-by first all-slots))]
-    (apply interleave-all split-up)
+  (->> (map (fn [[node-id slots]] [(count slots) slots]) (group-by first all-slots))
+    (mapcat (fn [[count slots]] (interleave (reverse (range count)) slots)))
+    (partition 2)
+    (sort-by (comp - (fn [[index bag]] index)))
+    (map last)
     ))
 
 (defn get-alive-assigned-node+port->executors [cluster topology-id]
@@ -49,10 +52,12 @@
 
 (defn schedule-topologies-evenly [^Topologies topologies ^Cluster cluster]
   (let [needs-scheduling-topologies (.needsSchedulingTopologies cluster topologies)]
+    (log-message "Needs scheduling topologies:" needs-scheduling-topologies)
     (doseq [^TopologyDetails topology needs-scheduling-topologies
             :let [topology-id (.getId topology)
                   new-assignment (schedule-topology topology cluster)
                   node+port->executors (reverse-map new-assignment)]]
+      (log-message "for topology " topology-id ", node+port->executors:" node+port->executors)
       (doseq [[node+port executors] node+port->executors
               :let [^WorkerSlot slot (WorkerSlot. (first node+port) (last node+port))
                     executors (for [[start-task end-task] executors]

--- a/src/clj/backtype/storm/scheduler/EvenScheduler.clj
+++ b/src/clj/backtype/storm/scheduler/EvenScheduler.clj
@@ -52,12 +52,10 @@
 
 (defn schedule-topologies-evenly [^Topologies topologies ^Cluster cluster]
   (let [needs-scheduling-topologies (.needsSchedulingTopologies cluster topologies)]
-    (log-message "Needs scheduling topologies:" needs-scheduling-topologies)
     (doseq [^TopologyDetails topology needs-scheduling-topologies
             :let [topology-id (.getId topology)
                   new-assignment (schedule-topology topology cluster)
                   node+port->executors (reverse-map new-assignment)]]
-      (log-message "for topology " topology-id ", node+port->executors:" node+port->executors)
       (doseq [[node+port executors] node+port->executors
               :let [^WorkerSlot slot (WorkerSlot. (first node+port) (last node+port))
                     executors (for [[start-task end-task] executors]

--- a/src/clj/backtype/storm/util.clj
+++ b/src/clj/backtype/storm/util.clj
@@ -579,16 +579,6 @@
     (Collections/shuffle state rand))
   (.get state (.get curr)))
 
-; this can be rewritten to be tail recursive
-(defn interleave-all [& colls]
-  (if (empty? colls)
-    []
-    (let [colls (filter (complement empty?) colls)
-          my-elems (map first colls)
-          rest-elems (apply interleave-all (map rest colls))]
-      (concat my-elems rest-elems)
-      )))
-
 (defn update [m k afn]
   (assoc m k (afn (get m k))))
 

--- a/test/clj/backtype/storm/scheduler_test.clj
+++ b/test/clj/backtype/storm/scheduler_test.clj
@@ -2,6 +2,7 @@
   (:use [clojure test])
   (:use [backtype.storm bootstrap config testing])
   (:import [backtype.storm.generated StormTopology])
+  (:require [backtype.storm.scheduler.EvenScheduler :as EvenScheduler])
   (:import [backtype.storm.scheduler Cluster SupervisorDetails WorkerSlot ExecutorDetails
             SchedulerAssignmentImpl Topologies TopologyDetails]))
 
@@ -164,7 +165,7 @@
     (is (= #{1 3 5} (set (.getUsedPorts cluster supervisor1))))
     (is (= #{2 4} (set (.getUsedPorts cluster supervisor2))))
     (is (= #{1 3 5} (set (.getUsedPorts cluster supervisor1))))
-    
+
     ;; test Cluster.getAvailablePorts
     (is (= #{7 9} (set (.getAvailablePorts cluster supervisor1))))
     (is (= #{6 8 10} (set (.getAvailablePorts cluster supervisor2))))
@@ -241,4 +242,37 @@
     (is (= false (.isSlotOccupied cluster (WorkerSlot. "supervisor1" (int 1)))))
     (is (= false (.isSlotOccupied cluster (WorkerSlot. "supervisor1" (int 3)))))
     (is (= false (.isSlotOccupied cluster (WorkerSlot. "supervisor1" (int 5)))))
+    ))
+
+(deftest test-use-resources-evenly
+  (let [supervisor1 (SupervisorDetails. "supervisor1" "192.168.0.1" (list ) (map int (list 1 3 5 7 9)))
+        supervisor2 (SupervisorDetails. "supervisor2" "192.168.0.2" (list ) (map int (list 2 4 6 8 10)))
+        executor1 (ExecutorDetails. (int 1001) (int 1001))
+        executor2 (ExecutorDetails. (int 1002) (int 1002))
+        executor3 (ExecutorDetails. (int 1003) (int 1003))
+        executor11 (ExecutorDetails. (int 1011) (int 1011))
+        executor12 (ExecutorDetails. (int 1012) (int 1012))
+        topology1 (TopologyDetails. "topology1" {TOPOLOGY-NAME "topology-name-1"}
+                                    (StormTopology.)
+                                    3
+                                    {executor1 "spout1"
+                                     executor2 "bolt1"
+                                     executor3 "bolt2"})
+        topology2 (TopologyDetails. "topology2" {TOPOLOGY-NAME "topology-name-2"}
+                                    (StormTopology.)
+                                    2
+                                    {executor11 "spout11"
+                                     executor12 "bolt11"})
+        topologies (Topologies. {"topology1" topology1 "topology2" topology2})
+        executor->slot1 {executor1 (WorkerSlot. "supervisor1" (int 1))
+                         executor2 (WorkerSlot. "supervisor1" (int 3))
+                         executor3 (WorkerSlot. "supervisor1" (int 5))}
+        assignment1 (SchedulerAssignmentImpl. "topology1" executor->slot1)
+        cluster (Cluster. {"supervisor1" supervisor1 "supervisor2" supervisor2}
+                          {"topology1" assignment1})]
+
+    (EvenScheduler/schedule-topologies-evenly topologies cluster)
+
+    (is (= #{1 3 5} (set (.getUsedPorts cluster supervisor1))))
+    (is (= #{2 4} (set (.getUsedPorts cluster supervisor2))))
     ))


### PR DESCRIPTION
https://github.com/nathanmarz/storm/issues/359

Updated `EvenScheduler/sort-slots` to take slots first from supervisors with the most available slots.
