### PR TITLE
Add a way to send an exception through shellbolt

### DIFF
--- a/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/src/jvm/backtype/storm/task/ShellBolt.java
@@ -181,9 +181,7 @@ public class ShellBolt implements IBolt {
 
     private void handleError(Map action) {
         String msg = (String) action.get("msg");
-        if (msg != null) {
-            _collector.reportError(new Exception("Shell Process Exception: " + msg));
-        }
+        _collector.reportError(new Exception("Shell Process Exception: " + msg));
     }
 
     private void handleEmit(Map action) throws InterruptedException {

--- a/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/src/jvm/backtype/storm/task/ShellBolt.java
@@ -97,6 +97,8 @@ public class ShellBolt implements IBolt {
                             handleAck(action);
                         } else if (command.equals("fail")) {
                             handleFail(action);
+                        } else if (command.equals("error")) {
+                            handleError(action);
                         } else if (command.equals("log")) {
                             String msg = (String) action.get("msg");
                             LOG.info("Shell msg: " + msg);
@@ -175,6 +177,13 @@ public class ShellBolt implements IBolt {
             throw new RuntimeException("Failed a non-existent or already acked/failed id: " + id);
         }
         _collector.fail(failed);
+    }
+
+    private void handleError(Map action) {
+        String msg = (String) action.get("msg");
+        if (msg != null) {
+            _collector.reportError(new Exception("Shell Process Exception: " + msg));
+        }
     }
 
     private void handleEmit(Map action) throws InterruptedException {

--- a/src/multilang/fy/storm.fy
+++ b/src/multilang/fy/storm.fy
@@ -86,6 +86,14 @@ class Storm {
       send: <['command => 'fail, 'id => tuple id]>
     }
 
+    def reportError: message {
+      """
+      @message Error mesasge to be reported to Storm
+      """
+
+      send: <['command => 'error, 'msg => message to_s]>
+    }
+
     def log: message {
       """
       @message Message to be logged by Storm.
@@ -153,7 +161,7 @@ class Storm {
           sync
         }
       } catch Exception => e {
-        log: e
+        reportError: e
       }
     }
   }

--- a/src/multilang/py/storm.py
+++ b/src/multilang/py/storm.py
@@ -65,7 +65,7 @@ def sync():
 def sendpid(heartbeatdir):
     pid = os.getpid()
     sendMsgToParent({'pid':pid})
-    open(heartbeatdir + "/" + str(pid), "w").close()    
+    open(heartbeatdir + "/" + str(pid), "w").close()
 
 def emit(*args, **kwargs):
     __emit(*args, **kwargs)
@@ -94,7 +94,7 @@ def emitBolt(tup, stream=None, anchors = [], directTask=None):
         m["task"] = directTask
     m["tuple"] = tup
     sendMsgToParent(m)
-    
+
 def emitSpout(tup, stream=None, id=None, directTask=None):
     m = {"command": "emit"}
     if id is not None:
@@ -111,6 +111,9 @@ def ack(tup):
 
 def fail(tup):
     sendMsgToParent({"command": "fail", "id": tup.id})
+
+def reportError(msg):
+    sendMsgToParent({"command": "error", "msg": msg})
 
 def log(msg):
     sendMsgToParent({"command": "log", "msg": msg})
@@ -150,7 +153,7 @@ class Bolt(object):
                 tup = readTuple()
                 self.process(tup)
         except Exception, e:
-            log(traceback.format_exc(e))
+            reportError(traceback.format_exc(e))
 
 class BasicBolt(object):
     def initialize(self, stormconf, context):
@@ -172,7 +175,7 @@ class BasicBolt(object):
                 self.process(tup)
                 ack(tup)
         except Exception, e:
-            log(traceback.format_exc(e))
+            reportError(traceback.format_exc(e))
 
 class Spout(object):
     def initialize(self, conf, context):
@@ -203,4 +206,4 @@ class Spout(object):
                     self.fail(msg["id"])
                 sync()
         except Exception, e:
-            log(traceback.format_exc(e))
+            reportError(traceback.format_exc(e))

--- a/src/multilang/rb/storm.rb
+++ b/src/multilang/rb/storm.rb
@@ -102,6 +102,10 @@ module Storm
       send_msg_to_parent :command => :fail, :id => tup.id
     end
 
+    def reportError(msg)
+      send_msg_to_parent :command => :error, :msg => msg.to_s
+    end
+
     def log(msg)
       send_msg_to_parent :command => :log, :msg => msg.to_s
     end
@@ -144,7 +148,7 @@ module Storm
           process Tuple.from_hash(read_command)
         end
       rescue Exception => e
-        log 'Exception in bolt: ' + e.message + ' - ' + e.backtrace.join('\n')
+        reportError 'Exception in bolt: ' + e.message + ' - ' + e.backtrace.join('\n')
       end
     end
   end
@@ -178,7 +182,7 @@ module Storm
           sync
         end
       rescue Exception => e
-        log 'Exception in spout: ' + e.message + ' - ' + e.backtrace.join('\n')
+        reportError 'Exception in spout: ' + e.message + ' - ' + e.backtrace.join('\n')
       end
     end
   end


### PR DESCRIPTION
This provides a valid command for shell processes send back an exception or general error message.  This would allow a viewable error in the UI for ease in production.

I continue to see "failed tuples" in my shell processes, but I can not see the underlying reason for them without seeking out the individual worker log and line.

This change should allow a user to see the passed exception from the shell process straight to the UI for easy diagnoses and debugging.

The only edit I would make is to either move this functionality to the "log" command or create a specific exception class like ShellTupleException for more clear messages.
