### PR TITLE
Allow Debug filters to print an identifier

### DIFF
--- a/src/jvm/storm/trident/operation/builtin/Debug.java
+++ b/src/jvm/storm/trident/operation/builtin/Debug.java
@@ -4,11 +4,19 @@ import storm.trident.operation.BaseFilter;
 import storm.trident.tuple.TridentTuple;
 
 public class Debug extends BaseFilter {
+    private final String name;
+
+    public Debug() {
+        name = "DEBUG: ";
+    }
+
+    public Debug(String name) {
+        this.name = "DEBUG(" + name + "): ";
+    }
 
     @Override
     public boolean isKeep(TridentTuple tuple) {
-        System.out.println("DEBUG: " + tuple.toString());
+        System.out.println(name + tuple.toString());
         return true;
     }
-    
 }


### PR DESCRIPTION
When multiple Debug filters share a worker, it can be difficult to determine what output is generated by each.  This will make it easy to split log output by Debug instances.
