### PR TITLE
kill --all flag

### DIFF
--- a/src/clj/backtype/storm/command/kill_topology.clj
+++ b/src/clj/backtype/storm/command/kill_topology.clj
@@ -4,11 +4,24 @@
   (:import [backtype.storm.generated KillOptions])
   (:gen-class))
 
+(defn kill-topology [nimbus name opts]
+  (.killTopologyWithOpts nimbus name opts)
+  (log-message "Killed topology: " name))
+
 (defn -main [& args]
-  (let [[{wait :wait} [name] _] (cli args ["-w" "--wait" :default nil :parse-fn #(Integer/parseInt %)])
+  (let [[{wait :wait all :all} [name] _]
+        (cli args ["-w" "--wait" :default nil :parse-fn #(Integer/parseInt %)]
+                  ["-a" "--all" :flag true])
         opts (KillOptions.)]
     (if wait (.set_wait_secs opts wait))
     (with-configured-nimbus-connection nimbus
-      (.killTopologyWithOpts nimbus name opts)
-      (log-message "Killed topology: " name)
+      (if name
+        (kill-topology nimbus name opts)
+        (do
+          (log-message "Killing all topologies...")
+          (doseq [topology (.get_topologies (.getClusterInfo nimbus))]
+            (let [name (.get_name topology)]
+              (kill-topology nimbus name opts)))
+          (log-message "All topologies killed")
+          ))
       )))


### PR DESCRIPTION
Simple way to kill all topologies in Storm cluster.

build: http://f.frostman.ru/tsc-dists/storm-0.8.2-wip15-killall.zip
