### PR TITLE
Fix race condition on zeromq sockets between the threads that send tuple...

### DIFF
--- a/src/clj/backtype/storm/daemon/worker.clj
+++ b/src/clj/backtype/storm/daemon/worker.clj
@@ -246,13 +246,13 @@
                          )))
               (write-locked (:endpoint-socket-lock worker)
                 (reset! (:cached-task->node+port worker)
-                        (HashMap. my-assignment)))
-              (doseq [endpoint remove-connections]
-                (.close (get @(:cached-node+port->socket worker) endpoint)))
-              (apply swap!
-                     (:cached-node+port->socket worker)
-                     #(HashMap. (dissoc (into {} %1) %&))
-                     remove-connections)
+                        (HashMap. my-assignment))
+                (doseq [endpoint remove-connections]
+                  (.close (get @(:cached-node+port->socket worker) endpoint)))
+                (apply swap!
+                       (:cached-node+port->socket worker)
+                       #(HashMap. (apply dissoc (into {} %1) %&))
+                       remove-connections))
               
               (let [missing-tasks (->> needed-tasks
                                        (filter (complement my-assignment)))]


### PR DESCRIPTION
Hi Nathan, we are facing the same issue as this one: http://groups.google.com/group/storm-user/browse_thread/thread/932da776159fd063 but we do not see java.lang.VerifyError as Dane did.

As we investigate the issue, we find that the cause of the problem is mainly due to the race condition on using and managing socket connections between the sender threads and the refresher thread.  If a worker finds that some of its downstream connections have dead, and refreshes the dead connections, the closed socket may contain NULL values and hence the crash happens.

A patch is attached.  How do you think about it?
