### PR TITLE
ui: use wrap-reload to detect changes in ui and reload

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -22,6 +22,7 @@
                  [com.googlecode.json-simple/json-simple "1.1"]
                  [compojure "0.6.4"]
                  [hiccup "0.3.6"]
+                 [ring/ring-devel "0.3.11"]
                  [ring/ring-jetty-adapter "0.3.11"]
                  [org.clojure/tools.logging "0.2.3"]
                  [org.clojure/math.numeric-tower "0.0.1"]

--- a/src/clj/backtype/storm/ui/core.clj
+++ b/src/clj/backtype/storm/ui/core.clj
@@ -1,5 +1,6 @@
 (ns backtype.storm.ui.core
   (:use compojure.core)
+  (:use ring.middleware.reload)
   (:use [hiccup core page-helpers])
   (:use [backtype.storm config util log])
   (:use [backtype.storm.ui helpers])
@@ -794,7 +795,9 @@
         ))))
 
 (def app
-  (handler/site (-> main-routes catch-errors )))
+  (-> #'main-routes
+      (wrap-reload '[backtype.storm.ui.core])
+      catch-errors))
 
 (defn start-server! [] (run-jetty app {:port (Integer. (*STORM-CONF* UI-PORT))
                                        :join? false}))


### PR DESCRIPTION
This reloads the UI whenever a change occurs in the backtype.storm.ui.core namespace. It's very useful if you're making changes to the UI, as you do not have to manually reload the UI each time -- you can see them reflected in the running UI immediately.
