### PR TITLE
 repeat defined taskId ?

### DIFF
--- a/src/clj/backtype/storm/daemon/task.clj
+++ b/src/clj/backtype/storm/daemon/task.clj
@@ -103,8 +103,8 @@
         stream->component->grouper (:stream->component->grouper executor-data)
         user-context (:user-context task-data)
         executor-stats (:stats executor-data)
-        debug? (= true (storm-conf TOPOLOGY-DEBUG))
-        task-id (:task-id task-data)]
+        debug? (= true (storm-conf TOPOLOGY-DEBUG))]
+        
     (fn ([^Integer out-task-id ^String stream ^List values]
           (when debug?
             (log-message "Emitting direct: " out-task-id "; " component-id " " stream " " values))


### PR DESCRIPTION
unnecessary (task-id (:task-id task-data)) 
if not , please tell me why repeat defined taskId
thanks
