### PR TITLE
fixed missing generic type params for trident

### DIFF
--- a/src/jvm/storm/trident/operation/builtin/MapGet.java
+++ b/src/jvm/storm/trident/operation/builtin/MapGet.java
@@ -8,14 +8,14 @@ import storm.trident.state.map.ReadOnlyMapState;
 import storm.trident.tuple.TridentTuple;
 
 
-public class MapGet extends BaseQueryFunction<ReadOnlyMapState, Object> {
+public class MapGet<T> extends BaseQueryFunction<ReadOnlyMapState<T>, T> {
     @Override
-    public List<Object> batchRetrieve(ReadOnlyMapState map, List<TridentTuple> keys) {
-        return map.multiGet((List) keys);
-    }    
-    
+    public List<T> batchRetrieve(ReadOnlyMapState<T> map, List<TridentTuple> keys) {
+        return map.multiGet(keys);
+    }
+
     @Override
     public void execute(TridentTuple tuple, Object result, TridentCollector collector) {
         collector.emit(new Values(result));
-    }    
+    }
 }

--- a/src/jvm/storm/trident/state/CombinerValueUpdater.java
+++ b/src/jvm/storm/trident/state/CombinerValueUpdater.java
@@ -2,17 +2,17 @@ package storm.trident.state;
 
 import storm.trident.operation.CombinerAggregator;
 
-public class CombinerValueUpdater implements ValueUpdater<Object> {
-    Object arg;
-    CombinerAggregator agg;
-    
-    public CombinerValueUpdater(CombinerAggregator agg, Object arg) {
+public class CombinerValueUpdater<T> implements ValueUpdater<T> {
+    T arg;
+    CombinerAggregator<T> agg;
+
+    public CombinerValueUpdater(CombinerAggregator<T> agg, T arg) {
         this.agg = agg;
         this.arg = arg;
     }
 
     @Override
-    public Object update(Object stored) {
+    public T update(T stored) {
         if(stored==null) return arg;
         else return agg.combine(stored, arg);
     }

--- a/src/jvm/storm/trident/state/JSONOpaqueSerializer.java
+++ b/src/jvm/storm/trident/state/JSONOpaqueSerializer.java
@@ -6,10 +6,11 @@ import java.util.List;
 import org.json.simple.JSONValue;
 
 
-public class JSONOpaqueSerializer implements Serializer<OpaqueValue> {
+public class JSONOpaqueSerializer<T> implements Serializer<OpaqueValue<T>> {
 
     @Override
-    public byte[] serialize(OpaqueValue obj) {
+    public byte[] serialize(OpaqueValue<T> obj) {
+        // not generic param T as currTxid is a long
         List toSer = new ArrayList(3);
         toSer.add(obj.currTxid);
         toSer.add(obj.curr);
@@ -22,14 +23,15 @@ public class JSONOpaqueSerializer implements Serializer<OpaqueValue> {
     }
 
     @Override
-    public OpaqueValue deserialize(byte[] b) {
+    public OpaqueValue<T> deserialize(byte[] b) {
         try {
             String s = new String(b, "UTF-8");
-            List deser = (List) JSONValue.parse(s);
+            List deser = List.class.cast(JSONValue.parse(s));
+            // not generic param T as currTxid is a long
             return new OpaqueValue((Long) deser.get(0), deser.get(1), deser.get(2));
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }
     }
-    
+
 }

--- a/src/jvm/storm/trident/state/ReducerValueUpdater.java
+++ b/src/jvm/storm/trident/state/ReducerValueUpdater.java
@@ -4,21 +4,21 @@ import java.util.List;
 import storm.trident.operation.ReducerAggregator;
 import storm.trident.tuple.TridentTuple;
 
-public class ReducerValueUpdater implements ValueUpdater<Object> {
+public class ReducerValueUpdater<T> implements ValueUpdater<T> {
     List<TridentTuple> tuples;
-    ReducerAggregator agg;
-    
-    public ReducerValueUpdater(ReducerAggregator agg, List<TridentTuple> tuples) {
+    ReducerAggregator<T> agg;
+
+    public ReducerValueUpdater(ReducerAggregator<T> agg, List<TridentTuple> tuples) {
         this.agg = agg;
         this.tuples = tuples;
     }
 
     @Override
-    public Object update(Object stored) {
-        Object ret = stored;
+    public T update(T stored) {
+        T ret = stored;
         for(TridentTuple t: tuples) {
            ret =  this.agg.reduce(ret, t);
         }
         return ret;
-    }        
+    }
 }

--- a/src/jvm/storm/trident/state/ValueUpdater.java
+++ b/src/jvm/storm/trident/state/ValueUpdater.java
@@ -1,6 +1,5 @@
 package storm.trident.state;
 
-
 public interface ValueUpdater<T> {
     T update(T stored);
 }

--- a/src/jvm/storm/trident/state/map/CachedBatchReadsMap.java
+++ b/src/jvm/storm/trident/state/map/CachedBatchReadsMap.java
@@ -8,15 +8,15 @@ import storm.trident.state.ValueUpdater;
 
 public class CachedBatchReadsMap<T> implements MapState<T> {
     Map<List<Object>, T> _cached = new HashMap<List<Object>, T>();
-    
+
     public MapState<T> _delegate;
-    
+
     public CachedBatchReadsMap(MapState<T> delegate) {
         _delegate = delegate;
     }
-    
+
     @Override
-    public List<T> multiGet(List<List<Object>> keys) {
+    public List<T> multiGet(List<? extends List<Object>> keys) {
         List<T> ret = _delegate.multiGet(keys);
         if(!_cached.isEmpty()) {
             ret = new ArrayList<T>(ret);
@@ -31,7 +31,7 @@ public class CachedBatchReadsMap<T> implements MapState<T> {
     }
 
     @Override
-    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
+    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater<T>> updaters) {
         List<T> vals = _delegate.multiUpdate(keys, updaters);
         cache(keys, vals);
         return vals;
@@ -42,7 +42,7 @@ public class CachedBatchReadsMap<T> implements MapState<T> {
         _delegate.multiPut(keys, vals);
         cache(keys, vals);
     }
-    
+
     private void cache(List<List<Object>> keys, List<T> vals) {
         for(int i=0; i<keys.size(); i++) {
             List<Object> key = keys.get(i);
@@ -62,5 +62,5 @@ public class CachedBatchReadsMap<T> implements MapState<T> {
         _cached.clear();
         _delegate.commit(txid);
     }
-    
+
 }

--- a/src/jvm/storm/trident/state/map/CachedMap.java
+++ b/src/jvm/storm/trident/state/map/CachedMap.java
@@ -21,7 +21,7 @@ public class CachedMap<T> implements IBackingMap<T> {
     }
 
     @Override
-    public List<T> multiGet(List<List<Object>> keys) {
+    public List<T> multiGet(List<? extends List<Object>> keys) {
         Map<List<Object>, T> results = new HashMap<List<Object>, T>();
         List<List<Object>> toGet = new ArrayList<List<Object>>();
         for(List<Object> key: keys) {
@@ -48,12 +48,12 @@ public class CachedMap<T> implements IBackingMap<T> {
     }
 
     @Override
-    public void multiPut(List<List<Object>> keys, List<T> values) {
+    public void multiPut(List<? extends List<Object>> keys, List<T> values) {
         cache(keys, values);
         _delegate.multiPut(keys, values);
     }
 
-    private void cache(List<List<Object>> keys, List<T> values) {
+    private void cache(List<? extends List<Object>> keys, List<T> values) {
         for(int i=0; i<keys.size(); i++) {
             _cache.put(keys.get(i), values.get(i));
         }

--- a/src/jvm/storm/trident/state/map/IBackingMap.java
+++ b/src/jvm/storm/trident/state/map/IBackingMap.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 
 public interface IBackingMap<T> {
-    List<T> multiGet(List<List<Object>> keys); 
-    void multiPut(List<List<Object>> keys, List<T> vals); 
+    List<T> multiGet(List<? extends List<Object>> keys);
+    void multiPut(List<? extends List<Object>> keys, List<T> vals);
 }

--- a/src/jvm/storm/trident/state/map/MapReducerAggStateUpdater.java
+++ b/src/jvm/storm/trident/state/map/MapReducerAggStateUpdater.java
@@ -3,9 +3,11 @@ package storm.trident.state.map;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.google.common.collect.Maps;
+
 import storm.trident.operation.ReducerAggregator;
 import storm.trident.operation.TridentCollector;
 import storm.trident.operation.TridentOperationContext;
@@ -16,44 +18,42 @@ import storm.trident.tuple.ComboList;
 import storm.trident.tuple.TridentTuple;
 import storm.trident.tuple.TridentTupleView.ProjectionFactory;
 
-public class MapReducerAggStateUpdater implements StateUpdater<MapState> {
-    ReducerAggregator _agg;
+public class MapReducerAggStateUpdater<T> implements StateUpdater<MapState<T>> {
+    ReducerAggregator<T> _agg;
     Fields _groupFields;
     Fields _inputFields;
     ProjectionFactory _groupFactory;
     ProjectionFactory _inputFactory;
     ComboList.Factory _factory;
-    
-    
-    public MapReducerAggStateUpdater(ReducerAggregator agg, Fields groupFields, Fields inputFields) {
+
+
+    public MapReducerAggStateUpdater(ReducerAggregator<T> agg, Fields groupFields, Fields inputFields) {
         _agg = agg;
         _groupFields = groupFields;
         _inputFields = inputFields;
         _factory = new ComboList.Factory(groupFields.size(), 1);
     }
-    
+
 
     @Override
-    public void updateState(MapState map, List<TridentTuple> tuples, TridentCollector collector) {
-        Map<List<Object>, List<TridentTuple>> grouped = new HashMap();
-        
-        List<List<Object>> groups = new ArrayList<List<Object>>(tuples.size());
-        List<Object> values = new ArrayList<Object>(tuples.size());
+    public void updateState(MapState<T> map, List<TridentTuple> tuples, TridentCollector collector) {
+        Map<List<Object>, List<TridentTuple>> grouped = Maps.newHashMap();
+
         for(TridentTuple t: tuples) {
             List<Object> group = _groupFactory.create(t);
             List<TridentTuple> groupTuples = grouped.get(group);
             if(groupTuples==null) {
-                groupTuples = new ArrayList();
+                groupTuples = new ArrayList<TridentTuple>();
                 grouped.put(group, groupTuples);
             }
             groupTuples.add(_inputFactory.create(t));
         }
-        List<List<Object>> uniqueGroups = new ArrayList(grouped.keySet());
-        List<ValueUpdater> updaters = new ArrayList(uniqueGroups.size());
+        List<List<Object>> uniqueGroups = new ArrayList<List<Object>>(grouped.keySet());
+        List<ValueUpdater<T>> updaters = new ArrayList<ValueUpdater<T>>(uniqueGroups.size());
         for(List<Object> group: uniqueGroups) {
-            updaters.add(new ReducerValueUpdater(_agg, grouped.get(group)));
+            updaters.add(new ReducerValueUpdater<T>(_agg, grouped.get(group)));
         }
-        List<Object> results = map.multiUpdate(uniqueGroups, updaters);
+        List<T> results = map.multiUpdate(uniqueGroups, updaters);
 
         for(int i=0; i<uniqueGroups.size(); i++) {
             List<Object> group = uniqueGroups.get(i);
@@ -71,5 +71,5 @@ public class MapReducerAggStateUpdater implements StateUpdater<MapState> {
     @Override
     public void cleanup() {
     }
-    
+
 }

--- a/src/jvm/storm/trident/state/map/MapState.java
+++ b/src/jvm/storm/trident/state/map/MapState.java
@@ -4,6 +4,6 @@ import java.util.List;
 import storm.trident.state.ValueUpdater;
 
 public interface MapState<T> extends ReadOnlyMapState<T> {
-    List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters);
+    List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater<T>> updaters);
     void multiPut(List<List<Object>> keys, List<T> vals);
 }

--- a/src/jvm/storm/trident/state/map/NonTransactionalMap.java
+++ b/src/jvm/storm/trident/state/map/NonTransactionalMap.java
@@ -10,20 +10,20 @@ public class NonTransactionalMap<T> implements MapState<T> {
     public static <T> MapState<T> build(IBackingMap<T> backing) {
         return new NonTransactionalMap<T>(backing);
     }
-    
+
     IBackingMap<T> _backing;
-    
+
     protected NonTransactionalMap(IBackingMap<T> backing) {
         _backing = backing;
     }
-    
+
     @Override
-    public List<T> multiGet(List<List<Object>> keys) {
+    public List<T> multiGet(List<? extends List<Object>> keys) {
         return _backing.multiGet(keys);
     }
 
     @Override
-    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
+    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater<T>> updaters) {
         List<T> curr = _backing.multiGet(keys);
         List<T> ret = new ArrayList<T>(curr.size());
         for(int i=0; i<curr.size(); i++) {
@@ -46,5 +46,5 @@ public class NonTransactionalMap<T> implements MapState<T> {
 
     @Override
     public void commit(Long txid) {
-    }  
+    }
 }

--- a/src/jvm/storm/trident/state/map/OpaqueMap.java
+++ b/src/jvm/storm/trident/state/map/OpaqueMap.java
@@ -8,24 +8,24 @@ import java.util.List;
 
 
 public class OpaqueMap<T> implements MapState<T> {
-    public static <T> MapState<T> build(IBackingMap<OpaqueValue> backing) {
+    public static <T> MapState<T> build(IBackingMap<OpaqueValue<T>> backing) {
         return new CachedBatchReadsMap<T>(new OpaqueMap<T>(backing));
     }
-    
-    IBackingMap<OpaqueValue> _backing;
+
+    IBackingMap<OpaqueValue<T>> _backing;
     Long _currTx;
-    
-    protected OpaqueMap(IBackingMap<OpaqueValue> backing) {
+
+    protected OpaqueMap(IBackingMap<OpaqueValue<T>> backing) {
         _backing = backing;
     }
-    
+
     @Override
-    public List<T> multiGet(List<List<Object>> keys) {
-        List<OpaqueValue> curr = _backing.multiGet(keys);
+    public List<T> multiGet(List<? extends List<Object>> keys) {
+        List<OpaqueValue<T>> curr = _backing.multiGet(keys);
         List<T> ret = new ArrayList<T>(curr.size());
-        for(OpaqueValue val: curr) {
+        for(OpaqueValue<T> val: curr) {
             if(val!=null) {
-                ret.add((T) val.get(_currTx));
+                ret.add(val.get(_currTx));
             } else {
                 ret.add(null);
             }
@@ -34,9 +34,9 @@ public class OpaqueMap<T> implements MapState<T> {
     }
 
     @Override
-    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
-        List<OpaqueValue> curr = _backing.multiGet(keys);
-        List<OpaqueValue> newVals = new ArrayList<OpaqueValue>(curr.size());
+    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater<T>> updaters) {
+        List<OpaqueValue<T>> curr = _backing.multiGet(keys);
+        List<OpaqueValue<T>> newVals = new ArrayList<OpaqueValue<T>>(curr.size());
         List<T> ret = new ArrayList<T>();
         for(int i=0; i<curr.size(); i++) {
             OpaqueValue<T> val = curr.get(i);
@@ -63,7 +63,7 @@ public class OpaqueMap<T> implements MapState<T> {
 
     @Override
     public void multiPut(List<List<Object>> keys, List<T> vals) {
-        List<ValueUpdater> updaters = new ArrayList<ValueUpdater>(vals.size());
+        List<ValueUpdater<T>> updaters = new ArrayList<ValueUpdater<T>>(vals.size());
         for(T val: vals) {
             updaters.add(new ReplaceUpdater<T>(val));
         }
@@ -79,17 +79,17 @@ public class OpaqueMap<T> implements MapState<T> {
     public void commit(Long txid) {
         _currTx = null;
     }
-    
+
     static class ReplaceUpdater<T> implements ValueUpdater<T> {
         T _t;
-        
+
         public ReplaceUpdater(T t) {
             _t = t;
         }
-        
+
         @Override
         public T update(Object stored) {
             return _t;
-        }        
-    }    
+        }
+    }
 }

--- a/src/jvm/storm/trident/state/map/ReadOnlyMapState.java
+++ b/src/jvm/storm/trident/state/map/ReadOnlyMapState.java
@@ -4,6 +4,6 @@ import java.util.List;
 import storm.trident.state.State;
 
 public interface ReadOnlyMapState<T> extends State {
-    // certain states might only accept one-tuple keys - those should just throw an error 
-    List<T> multiGet(List<List<Object>> keys);
+    // certain states might only accept one-tuple keys - those should just throw an error
+    List<T> multiGet(List<? extends List<Object>> keys);
 }

--- a/src/jvm/storm/trident/state/map/SnapshottableMap.java
+++ b/src/jvm/storm/trident/state/map/SnapshottableMap.java
@@ -16,12 +16,12 @@ public class SnapshottableMap<T> implements MapState<T>, Snapshottable<T> {
     }
 
     @Override
-    public List<T> multiGet(List<List<Object>> keys) {
+    public List<T> multiGet(List<? extends List<Object>> keys) {
         return _delegate.multiGet(keys);
     }
 
     @Override
-    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
+    public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater<T>> updaters) {
         return _delegate.multiUpdate(keys, updaters);
     }
 
@@ -46,8 +46,8 @@ public class SnapshottableMap<T> implements MapState<T>, Snapshottable<T> {
     }
 
     @Override
-    public T update(ValueUpdater updater) {
-        List<ValueUpdater> updaters = Arrays.asList(updater);
+    public T update(ValueUpdater<T> updater) {
+        List<ValueUpdater<T>> updaters = Arrays.asList(updater);
         return multiUpdate(_keys, updaters).get(0);
     }
 
@@ -55,5 +55,5 @@ public class SnapshottableMap<T> implements MapState<T>, Snapshottable<T> {
     public void set(T o) {
         multiPut(_keys, Arrays.asList(o));
     }
-    
+
 }

--- a/src/jvm/storm/trident/state/snapshot/Snapshottable.java
+++ b/src/jvm/storm/trident/state/snapshot/Snapshottable.java
@@ -5,6 +5,6 @@ import storm.trident.state.ValueUpdater;
 
 // used by Stream#persistentAggregate
 public interface Snapshottable<T> extends ReadOnlySnapshottable<T> {
-    T update(ValueUpdater updater);
+    T update(ValueUpdater<T> updater);
     void set(T o);
 }


### PR DESCRIPTION
fixed a series of generic type params in trident, typically where Object  or unspecified types were used when a value type is warranted.

You'll notice a switch from List<List<Object> to List<? extends List<Object>>.  This is to permit backtype.storm.tuple.Values without casting.
