### PR TITLE
Drain error stream periodically to avoid dead lock between ShellBolt and shell process

### DIFF
--- a/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/src/jvm/backtype/storm/task/ShellBolt.java
@@ -123,6 +123,8 @@ public class ShellBolt implements IBolt {
                         if (write != null) {
                             _process.writeMessage(write);
                         }
+                        // drain the error stream to avoid dead lock because of full error stream buffer
+                        _process.drainErrorStream();
                     } catch (InterruptedException e) {
                     } catch (Throwable t) {
                         die(t);

--- a/src/jvm/backtype/storm/utils/ShellProcess.java
+++ b/src/jvm/backtype/storm/utils/ShellProcess.java
@@ -13,8 +13,10 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
+import org.apache.log4j.Logger;
 
 public class ShellProcess {
+    public static Logger LOG = Logger.getLogger(ShellProcess.class);
     private DataOutputStream processIn;
     private BufferedReader processOut;
     private InputStream processErrorStream;
@@ -80,6 +82,22 @@ public class ShellProcess {
         }
     }
 
+    public void drainErrorStream()
+    {
+        try {
+            while (processErrorStream.available() > 0)
+            {
+                int bufferSize = processErrorStream.available();
+                byte[] errorReadingBuffer =  new byte[bufferSize];
+
+                processErrorStream.read(errorReadingBuffer, 0, bufferSize);
+
+                LOG.info("Got error from shell process: " + new String(errorReadingBuffer));
+            }
+        } catch(Exception e) {
+        }
+    }
+
     private String readString() throws IOException {
         StringBuilder line = new StringBuilder();
 
@@ -95,8 +113,6 @@ public class ShellProcess {
                     else {
                         errorMessage.append(" Currently read output: " + line.toString() + "\n");
                     }
-                    errorMessage.append("Shell Process Exception:\n");
-                    errorMessage.append(getErrorsString() + "\n");
                     throw new RuntimeException(errorMessage.toString());
                 }
                 if(subline.equals("end")) {


### PR DESCRIPTION
In this fix, I periodically drain the error stream so that if the buffer of error stream of shell process becomes full, it won't be blocked there thus result it dead lock between ShellBolt and the shell process.

I put the error stream reading logic in the writing thread as there's no non-blocking api to read error stream, if we read error stream in reading thread, we need to do some looping and sleeping, which impact the performance of normal reading. And it's not worthy to create another thread to do this. I think normally we can assume there won't be too much data output to error stream, so just periodically drain the error stream in writing thread seems enough.
