### PR TITLE
Fix issue #403

### DIFF
--- a/src/clj/backtype/storm/daemon/worker.clj
+++ b/src/clj/backtype/storm/daemon/worker.clj
@@ -252,7 +252,7 @@
                 (.close (get @(:cached-node+port->socket worker) endpoint)))
               (apply swap!
                      (:cached-node+port->socket worker)
-                     #(HashMap. (dissoc (into {} %1) %&))
+                     #(HashMap. (apply dissoc (into {} %1) %&))
                      remove-connections)
               
               (let [missing-tasks (->> needed-tasks


### PR DESCRIPTION
Hi Nathan, I believe this patch fixes issue #403.

You are right, it was not race condition, but rather some already closed sockets might be left in the new cached sockets map, due to the wrong invocation to dissoc.
