### PR TITLE
fix for storm issuse #245 hashCode does not work for byte[]

### DIFF
--- a/src/clj/backtype/storm/tuple.clj
+++ b/src/clj/backtype/storm/tuple.clj
@@ -5,4 +5,4 @@
 (bootstrap)
 
 (defn list-hash-code [^List alist]
-  (.hashCode alist))
+  (java.util.Arrays/deepHashCode (.toArray alist)))


### PR DESCRIPTION
use java.util.Arrays.deepHashCode() instead of List.hashCode() for tuple
