### PR TITLE
build: clean possible warning when running build_release.sh

### DIFF
--- a/bin/build_release.sh
+++ b/bin/build_release.sh
@@ -8,8 +8,8 @@ DIR=_release/storm-$RELEASE
 
 rm -rf _release
 export LEIN_ROOT=1
-rm *.zip
-rm *jar
+rm -f *.zip
+rm -f *jar
 rm -rf lib
 rm -rf classes
 lein deps


### PR DESCRIPTION
Always use -f argument when using rm, to avoid "file not exist" warning in the
first time build.
