### PR TITLE
Include worker PIDs in supervisor heartbeat/Thrift API

### DIFF
--- a/src/clj/backtype/storm/daemon/common.clj
+++ b/src/clj/backtype/storm/daemon/common.clj
@@ -35,7 +35,7 @@
 ;; component->executors is a map from spout/bolt id to number of executors for that component
 (defrecord StormBase [storm-name launch-time-secs status num-workers component->executors])
 
-(defrecord SupervisorInfo [time-secs hostname assignment-id used-ports meta scheduler-meta uptime-secs])
+(defrecord SupervisorInfo [time-secs hostname assignment-id used-ports worker-pids meta scheduler-meta uptime-secs])
 
 (defprotocol DaemonCommon
   (waiting? [this]))

--- a/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1034,6 +1034,7 @@
                                                                 (:uptime-secs info)
                                                                 (count ports)
                                                                 (count (:used-ports info))
+								(:worker-pids info)
                                                                 id )
                                             ))
               nimbus-uptime ((:uptime nimbus))

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -162,7 +162,7 @@
       (ensure-process-killed! pid)
       (rmpath (worker-pid-path conf id pid))
       )
-    (swap! (:worker-thread-pids-atom supervisor) dissoc worker-id)
+    (swap! (:worker-thread-pids-atom supervisor) dissoc id)
     (try-cleanup-worker conf id))
   (log-message "Shut down " (:supervisor-id supervisor) ":" id))
 

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -162,6 +162,7 @@
       (ensure-process-killed! pid)
       (rmpath (worker-pid-path conf id pid))
       )
+    (swap! (:worker-thread-pids-atom supervisor) dissoc worker-id)
     (try-cleanup-worker conf id))
   (log-message "Shut down " (:supervisor-id supervisor) ":" id))
 
@@ -424,9 +425,10 @@
                        " -Dlogback.configurationFile=logback/cluster.xml"
                        " -cp " classpath " backtype.storm.daemon.worker "
                        (java.net.URLEncoder/encode storm-id) " " (:assignment-id supervisor)
-                       " " port " " worker-id)]
-      (log-message "Launching worker with command: " command)
-      (launch-process command :environment {"LD_LIBRARY_PATH" (conf JAVA-LIBRARY-PATH)})
+                       " " port " " worker-id)
+	  pr (do (log-message "Launching worker with command: " command)
+		 (launch-process command :environment {"LD_LIBRARY_PATH" (conf JAVA-LIBRARY-PATH)}))]
+      (swap! (:worker-thread-pids-atom supervisor) assoc worker-id (get-process-pid pr))
       ))
 
 ;; local implementation

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -336,14 +336,16 @@
         heartbeat-fn (fn [] (.supervisor-heartbeat!
                                (:storm-cluster-state supervisor)
                                (:supervisor-id supervisor)
-                               (SupervisorInfo. (current-time-secs)
-                                                (:my-hostname supervisor)
-                                                (:assignment-id supervisor)
-                                                (keys @(:curr-assignment supervisor))
-                                                ;; used ports
-                                                (.getMetadata isupervisor)
-                                                (conf SUPERVISOR-SCHEDULER-META)
-                                                ((:uptime supervisor)))))]
+                               (SupervisorInfo.
+				(current-time-secs)
+				(:my-hostname supervisor)
+				(:assignment-id supervisor)
+				(keys @(:curr-assignment supervisor))
+				;; used ports
+				@(:worker-thread-pids-atom supervisor)
+				(.getMetadata isupervisor)
+				(conf SUPERVISOR-SCHEDULER-META)
+				((:uptime supervisor)))))]
     (heartbeat-fn)
     ;; should synchronize supervisor so it doesn't launch anything after being down (optimization)
     (schedule-recurring (:timer supervisor)

--- a/src/clj/backtype/storm/util.clj
+++ b/src/clj/backtype/storm/util.clj
@@ -316,6 +316,14 @@
     (first split)
     ))
 
+(defn get-process-pid
+  "Gets the pid of the Process. This is platform dependent, should work on OS X and Linux but not Windows."
+  [process]
+  (let [pidField (doto (.getDeclaredField ; pid is a private field
+			(Class/forName "java.lang.UNIXProcess") "pid")
+		   (.setAccessible true))]
+    (.get pidField process)))
+
 (defn exec-command! [command]
   (let [[comm-str & args] (seq (.split command " "))
         command (CommandLine. comm-str)]

--- a/src/jvm/backtype/storm/generated/BoltStats.java
+++ b/src/jvm/backtype/storm/generated/BoltStats.java
@@ -740,28 +740,28 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
         case 1: // ACKED
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map45 = iprot.readMapBegin();
-              this.acked = new HashMap<String,Map<GlobalStreamId,Long>>(2*_map45.size);
-              for (int _i46 = 0; _i46 < _map45.size; ++_i46)
+              org.apache.thrift7.protocol.TMap _map49 = iprot.readMapBegin();
+              this.acked = new HashMap<String,Map<GlobalStreamId,Long>>(2*_map49.size);
+              for (int _i50 = 0; _i50 < _map49.size; ++_i50)
               {
-                String _key47; // required
-                Map<GlobalStreamId,Long> _val48; // required
-                _key47 = iprot.readString();
+                String _key51; // required
+                Map<GlobalStreamId,Long> _val52; // required
+                _key51 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map49 = iprot.readMapBegin();
-                  _val48 = new HashMap<GlobalStreamId,Long>(2*_map49.size);
-                  for (int _i50 = 0; _i50 < _map49.size; ++_i50)
+                  org.apache.thrift7.protocol.TMap _map53 = iprot.readMapBegin();
+                  _val52 = new HashMap<GlobalStreamId,Long>(2*_map53.size);
+                  for (int _i54 = 0; _i54 < _map53.size; ++_i54)
                   {
-                    GlobalStreamId _key51; // required
-                    long _val52; // required
-                    _key51 = new GlobalStreamId();
-                    _key51.read(iprot);
-                    _val52 = iprot.readI64();
-                    _val48.put(_key51, _val52);
+                    GlobalStreamId _key55; // required
+                    long _val56; // required
+                    _key55 = new GlobalStreamId();
+                    _key55.read(iprot);
+                    _val56 = iprot.readI64();
+                    _val52.put(_key55, _val56);
                   }
                   iprot.readMapEnd();
                 }
-                this.acked.put(_key47, _val48);
+                this.acked.put(_key51, _val52);
               }
               iprot.readMapEnd();
             }
@@ -772,28 +772,28 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
         case 2: // FAILED
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map53 = iprot.readMapBegin();
-              this.failed = new HashMap<String,Map<GlobalStreamId,Long>>(2*_map53.size);
-              for (int _i54 = 0; _i54 < _map53.size; ++_i54)
+              org.apache.thrift7.protocol.TMap _map57 = iprot.readMapBegin();
+              this.failed = new HashMap<String,Map<GlobalStreamId,Long>>(2*_map57.size);
+              for (int _i58 = 0; _i58 < _map57.size; ++_i58)
               {
-                String _key55; // required
-                Map<GlobalStreamId,Long> _val56; // required
-                _key55 = iprot.readString();
+                String _key59; // required
+                Map<GlobalStreamId,Long> _val60; // required
+                _key59 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map57 = iprot.readMapBegin();
-                  _val56 = new HashMap<GlobalStreamId,Long>(2*_map57.size);
-                  for (int _i58 = 0; _i58 < _map57.size; ++_i58)
+                  org.apache.thrift7.protocol.TMap _map61 = iprot.readMapBegin();
+                  _val60 = new HashMap<GlobalStreamId,Long>(2*_map61.size);
+                  for (int _i62 = 0; _i62 < _map61.size; ++_i62)
                   {
-                    GlobalStreamId _key59; // required
-                    long _val60; // required
-                    _key59 = new GlobalStreamId();
-                    _key59.read(iprot);
-                    _val60 = iprot.readI64();
-                    _val56.put(_key59, _val60);
+                    GlobalStreamId _key63; // required
+                    long _val64; // required
+                    _key63 = new GlobalStreamId();
+                    _key63.read(iprot);
+                    _val64 = iprot.readI64();
+                    _val60.put(_key63, _val64);
                   }
                   iprot.readMapEnd();
                 }
-                this.failed.put(_key55, _val56);
+                this.failed.put(_key59, _val60);
               }
               iprot.readMapEnd();
             }
@@ -804,28 +804,28 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
         case 3: // PROCESS_MS_AVG
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map61 = iprot.readMapBegin();
-              this.process_ms_avg = new HashMap<String,Map<GlobalStreamId,Double>>(2*_map61.size);
-              for (int _i62 = 0; _i62 < _map61.size; ++_i62)
+              org.apache.thrift7.protocol.TMap _map65 = iprot.readMapBegin();
+              this.process_ms_avg = new HashMap<String,Map<GlobalStreamId,Double>>(2*_map65.size);
+              for (int _i66 = 0; _i66 < _map65.size; ++_i66)
               {
-                String _key63; // required
-                Map<GlobalStreamId,Double> _val64; // required
-                _key63 = iprot.readString();
+                String _key67; // required
+                Map<GlobalStreamId,Double> _val68; // required
+                _key67 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map65 = iprot.readMapBegin();
-                  _val64 = new HashMap<GlobalStreamId,Double>(2*_map65.size);
-                  for (int _i66 = 0; _i66 < _map65.size; ++_i66)
+                  org.apache.thrift7.protocol.TMap _map69 = iprot.readMapBegin();
+                  _val68 = new HashMap<GlobalStreamId,Double>(2*_map69.size);
+                  for (int _i70 = 0; _i70 < _map69.size; ++_i70)
                   {
-                    GlobalStreamId _key67; // required
-                    double _val68; // required
-                    _key67 = new GlobalStreamId();
-                    _key67.read(iprot);
-                    _val68 = iprot.readDouble();
-                    _val64.put(_key67, _val68);
+                    GlobalStreamId _key71; // required
+                    double _val72; // required
+                    _key71 = new GlobalStreamId();
+                    _key71.read(iprot);
+                    _val72 = iprot.readDouble();
+                    _val68.put(_key71, _val72);
                   }
                   iprot.readMapEnd();
                 }
-                this.process_ms_avg.put(_key63, _val64);
+                this.process_ms_avg.put(_key67, _val68);
               }
               iprot.readMapEnd();
             }
@@ -836,28 +836,28 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
         case 4: // EXECUTED
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map69 = iprot.readMapBegin();
-              this.executed = new HashMap<String,Map<GlobalStreamId,Long>>(2*_map69.size);
-              for (int _i70 = 0; _i70 < _map69.size; ++_i70)
+              org.apache.thrift7.protocol.TMap _map73 = iprot.readMapBegin();
+              this.executed = new HashMap<String,Map<GlobalStreamId,Long>>(2*_map73.size);
+              for (int _i74 = 0; _i74 < _map73.size; ++_i74)
               {
-                String _key71; // required
-                Map<GlobalStreamId,Long> _val72; // required
-                _key71 = iprot.readString();
+                String _key75; // required
+                Map<GlobalStreamId,Long> _val76; // required
+                _key75 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map73 = iprot.readMapBegin();
-                  _val72 = new HashMap<GlobalStreamId,Long>(2*_map73.size);
-                  for (int _i74 = 0; _i74 < _map73.size; ++_i74)
+                  org.apache.thrift7.protocol.TMap _map77 = iprot.readMapBegin();
+                  _val76 = new HashMap<GlobalStreamId,Long>(2*_map77.size);
+                  for (int _i78 = 0; _i78 < _map77.size; ++_i78)
                   {
-                    GlobalStreamId _key75; // required
-                    long _val76; // required
-                    _key75 = new GlobalStreamId();
-                    _key75.read(iprot);
-                    _val76 = iprot.readI64();
-                    _val72.put(_key75, _val76);
+                    GlobalStreamId _key79; // required
+                    long _val80; // required
+                    _key79 = new GlobalStreamId();
+                    _key79.read(iprot);
+                    _val80 = iprot.readI64();
+                    _val76.put(_key79, _val80);
                   }
                   iprot.readMapEnd();
                 }
-                this.executed.put(_key71, _val72);
+                this.executed.put(_key75, _val76);
               }
               iprot.readMapEnd();
             }
@@ -868,28 +868,28 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
         case 5: // EXECUTE_MS_AVG
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map77 = iprot.readMapBegin();
-              this.execute_ms_avg = new HashMap<String,Map<GlobalStreamId,Double>>(2*_map77.size);
-              for (int _i78 = 0; _i78 < _map77.size; ++_i78)
+              org.apache.thrift7.protocol.TMap _map81 = iprot.readMapBegin();
+              this.execute_ms_avg = new HashMap<String,Map<GlobalStreamId,Double>>(2*_map81.size);
+              for (int _i82 = 0; _i82 < _map81.size; ++_i82)
               {
-                String _key79; // required
-                Map<GlobalStreamId,Double> _val80; // required
-                _key79 = iprot.readString();
+                String _key83; // required
+                Map<GlobalStreamId,Double> _val84; // required
+                _key83 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map81 = iprot.readMapBegin();
-                  _val80 = new HashMap<GlobalStreamId,Double>(2*_map81.size);
-                  for (int _i82 = 0; _i82 < _map81.size; ++_i82)
+                  org.apache.thrift7.protocol.TMap _map85 = iprot.readMapBegin();
+                  _val84 = new HashMap<GlobalStreamId,Double>(2*_map85.size);
+                  for (int _i86 = 0; _i86 < _map85.size; ++_i86)
                   {
-                    GlobalStreamId _key83; // required
-                    double _val84; // required
-                    _key83 = new GlobalStreamId();
-                    _key83.read(iprot);
-                    _val84 = iprot.readDouble();
-                    _val80.put(_key83, _val84);
+                    GlobalStreamId _key87; // required
+                    double _val88; // required
+                    _key87 = new GlobalStreamId();
+                    _key87.read(iprot);
+                    _val88 = iprot.readDouble();
+                    _val84.put(_key87, _val88);
                   }
                   iprot.readMapEnd();
                 }
-                this.execute_ms_avg.put(_key79, _val80);
+                this.execute_ms_avg.put(_key83, _val84);
               }
               iprot.readMapEnd();
             }
@@ -914,15 +914,15 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
       oprot.writeFieldBegin(ACKED_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.acked.size()));
-        for (Map.Entry<String, Map<GlobalStreamId,Long>> _iter85 : this.acked.entrySet())
+        for (Map.Entry<String, Map<GlobalStreamId,Long>> _iter89 : this.acked.entrySet())
         {
-          oprot.writeString(_iter85.getKey());
+          oprot.writeString(_iter89.getKey());
           {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRUCT, org.apache.thrift7.protocol.TType.I64, _iter85.getValue().size()));
-            for (Map.Entry<GlobalStreamId, Long> _iter86 : _iter85.getValue().entrySet())
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRUCT, org.apache.thrift7.protocol.TType.I64, _iter89.getValue().size()));
+            for (Map.Entry<GlobalStreamId, Long> _iter90 : _iter89.getValue().entrySet())
             {
-              _iter86.getKey().write(oprot);
-              oprot.writeI64(_iter86.getValue());
+              _iter90.getKey().write(oprot);
+              oprot.writeI64(_iter90.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -935,49 +935,7 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
       oprot.writeFieldBegin(FAILED_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.failed.size()));
-        for (Map.Entry<String, Map<GlobalStreamId,Long>> _iter87 : this.failed.entrySet())
-        {
-          oprot.writeString(_iter87.getKey());
-          {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRUCT, org.apache.thrift7.protocol.TType.I64, _iter87.getValue().size()));
-            for (Map.Entry<GlobalStreamId, Long> _iter88 : _iter87.getValue().entrySet())
-            {
-              _iter88.getKey().write(oprot);
-              oprot.writeI64(_iter88.getValue());
-            }
-            oprot.writeMapEnd();
-          }
-        }
-        oprot.writeMapEnd();
-      }
-      oprot.writeFieldEnd();
-    }
-    if (this.process_ms_avg != null) {
-      oprot.writeFieldBegin(PROCESS_MS_AVG_FIELD_DESC);
-      {
-        oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.process_ms_avg.size()));
-        for (Map.Entry<String, Map<GlobalStreamId,Double>> _iter89 : this.process_ms_avg.entrySet())
-        {
-          oprot.writeString(_iter89.getKey());
-          {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRUCT, org.apache.thrift7.protocol.TType.DOUBLE, _iter89.getValue().size()));
-            for (Map.Entry<GlobalStreamId, Double> _iter90 : _iter89.getValue().entrySet())
-            {
-              _iter90.getKey().write(oprot);
-              oprot.writeDouble(_iter90.getValue());
-            }
-            oprot.writeMapEnd();
-          }
-        }
-        oprot.writeMapEnd();
-      }
-      oprot.writeFieldEnd();
-    }
-    if (this.executed != null) {
-      oprot.writeFieldBegin(EXECUTED_FIELD_DESC);
-      {
-        oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.executed.size()));
-        for (Map.Entry<String, Map<GlobalStreamId,Long>> _iter91 : this.executed.entrySet())
+        for (Map.Entry<String, Map<GlobalStreamId,Long>> _iter91 : this.failed.entrySet())
         {
           oprot.writeString(_iter91.getKey());
           {
@@ -994,11 +952,11 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
       }
       oprot.writeFieldEnd();
     }
-    if (this.execute_ms_avg != null) {
-      oprot.writeFieldBegin(EXECUTE_MS_AVG_FIELD_DESC);
+    if (this.process_ms_avg != null) {
+      oprot.writeFieldBegin(PROCESS_MS_AVG_FIELD_DESC);
       {
-        oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.execute_ms_avg.size()));
-        for (Map.Entry<String, Map<GlobalStreamId,Double>> _iter93 : this.execute_ms_avg.entrySet())
+        oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.process_ms_avg.size()));
+        for (Map.Entry<String, Map<GlobalStreamId,Double>> _iter93 : this.process_ms_avg.entrySet())
         {
           oprot.writeString(_iter93.getKey());
           {
@@ -1007,6 +965,48 @@ public class BoltStats implements org.apache.thrift7.TBase<BoltStats, BoltStats.
             {
               _iter94.getKey().write(oprot);
               oprot.writeDouble(_iter94.getValue());
+            }
+            oprot.writeMapEnd();
+          }
+        }
+        oprot.writeMapEnd();
+      }
+      oprot.writeFieldEnd();
+    }
+    if (this.executed != null) {
+      oprot.writeFieldBegin(EXECUTED_FIELD_DESC);
+      {
+        oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.executed.size()));
+        for (Map.Entry<String, Map<GlobalStreamId,Long>> _iter95 : this.executed.entrySet())
+        {
+          oprot.writeString(_iter95.getKey());
+          {
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRUCT, org.apache.thrift7.protocol.TType.I64, _iter95.getValue().size()));
+            for (Map.Entry<GlobalStreamId, Long> _iter96 : _iter95.getValue().entrySet())
+            {
+              _iter96.getKey().write(oprot);
+              oprot.writeI64(_iter96.getValue());
+            }
+            oprot.writeMapEnd();
+          }
+        }
+        oprot.writeMapEnd();
+      }
+      oprot.writeFieldEnd();
+    }
+    if (this.execute_ms_avg != null) {
+      oprot.writeFieldBegin(EXECUTE_MS_AVG_FIELD_DESC);
+      {
+        oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.execute_ms_avg.size()));
+        for (Map.Entry<String, Map<GlobalStreamId,Double>> _iter97 : this.execute_ms_avg.entrySet())
+        {
+          oprot.writeString(_iter97.getKey());
+          {
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRUCT, org.apache.thrift7.protocol.TType.DOUBLE, _iter97.getValue().size()));
+            for (Map.Entry<GlobalStreamId, Double> _iter98 : _iter97.getValue().entrySet())
+            {
+              _iter98.getKey().write(oprot);
+              oprot.writeDouble(_iter98.getValue());
             }
             oprot.writeMapEnd();
           }

--- a/src/jvm/backtype/storm/generated/ClusterSummary.java
+++ b/src/jvm/backtype/storm/generated/ClusterSummary.java
@@ -447,14 +447,14 @@ public class ClusterSummary implements org.apache.thrift7.TBase<ClusterSummary, 
         case 1: // SUPERVISORS
           if (field.type == org.apache.thrift7.protocol.TType.LIST) {
             {
-              org.apache.thrift7.protocol.TList _list37 = iprot.readListBegin();
-              this.supervisors = new ArrayList<SupervisorSummary>(_list37.size);
-              for (int _i38 = 0; _i38 < _list37.size; ++_i38)
+              org.apache.thrift7.protocol.TList _list41 = iprot.readListBegin();
+              this.supervisors = new ArrayList<SupervisorSummary>(_list41.size);
+              for (int _i42 = 0; _i42 < _list41.size; ++_i42)
               {
-                SupervisorSummary _elem39; // required
-                _elem39 = new SupervisorSummary();
-                _elem39.read(iprot);
-                this.supervisors.add(_elem39);
+                SupervisorSummary _elem43; // required
+                _elem43 = new SupervisorSummary();
+                _elem43.read(iprot);
+                this.supervisors.add(_elem43);
               }
               iprot.readListEnd();
             }
@@ -473,14 +473,14 @@ public class ClusterSummary implements org.apache.thrift7.TBase<ClusterSummary, 
         case 3: // TOPOLOGIES
           if (field.type == org.apache.thrift7.protocol.TType.LIST) {
             {
-              org.apache.thrift7.protocol.TList _list40 = iprot.readListBegin();
-              this.topologies = new ArrayList<TopologySummary>(_list40.size);
-              for (int _i41 = 0; _i41 < _list40.size; ++_i41)
+              org.apache.thrift7.protocol.TList _list44 = iprot.readListBegin();
+              this.topologies = new ArrayList<TopologySummary>(_list44.size);
+              for (int _i45 = 0; _i45 < _list44.size; ++_i45)
               {
-                TopologySummary _elem42; // required
-                _elem42 = new TopologySummary();
-                _elem42.read(iprot);
-                this.topologies.add(_elem42);
+                TopologySummary _elem46; // required
+                _elem46 = new TopologySummary();
+                _elem46.read(iprot);
+                this.topologies.add(_elem46);
               }
               iprot.readListEnd();
             }
@@ -505,9 +505,9 @@ public class ClusterSummary implements org.apache.thrift7.TBase<ClusterSummary, 
       oprot.writeFieldBegin(SUPERVISORS_FIELD_DESC);
       {
         oprot.writeListBegin(new org.apache.thrift7.protocol.TList(org.apache.thrift7.protocol.TType.STRUCT, this.supervisors.size()));
-        for (SupervisorSummary _iter43 : this.supervisors)
+        for (SupervisorSummary _iter47 : this.supervisors)
         {
-          _iter43.write(oprot);
+          _iter47.write(oprot);
         }
         oprot.writeListEnd();
       }
@@ -520,9 +520,9 @@ public class ClusterSummary implements org.apache.thrift7.TBase<ClusterSummary, 
       oprot.writeFieldBegin(TOPOLOGIES_FIELD_DESC);
       {
         oprot.writeListBegin(new org.apache.thrift7.protocol.TList(org.apache.thrift7.protocol.TType.STRUCT, this.topologies.size()));
-        for (TopologySummary _iter44 : this.topologies)
+        for (TopologySummary _iter48 : this.topologies)
         {
-          _iter44.write(oprot);
+          _iter48.write(oprot);
         }
         oprot.writeListEnd();
       }

--- a/src/jvm/backtype/storm/generated/ExecutorStats.java
+++ b/src/jvm/backtype/storm/generated/ExecutorStats.java
@@ -480,27 +480,27 @@ public class ExecutorStats implements org.apache.thrift7.TBase<ExecutorStats, Ex
         case 1: // EMITTED
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map125 = iprot.readMapBegin();
-              this.emitted = new HashMap<String,Map<String,Long>>(2*_map125.size);
-              for (int _i126 = 0; _i126 < _map125.size; ++_i126)
+              org.apache.thrift7.protocol.TMap _map129 = iprot.readMapBegin();
+              this.emitted = new HashMap<String,Map<String,Long>>(2*_map129.size);
+              for (int _i130 = 0; _i130 < _map129.size; ++_i130)
               {
-                String _key127; // required
-                Map<String,Long> _val128; // required
-                _key127 = iprot.readString();
+                String _key131; // required
+                Map<String,Long> _val132; // required
+                _key131 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map129 = iprot.readMapBegin();
-                  _val128 = new HashMap<String,Long>(2*_map129.size);
-                  for (int _i130 = 0; _i130 < _map129.size; ++_i130)
+                  org.apache.thrift7.protocol.TMap _map133 = iprot.readMapBegin();
+                  _val132 = new HashMap<String,Long>(2*_map133.size);
+                  for (int _i134 = 0; _i134 < _map133.size; ++_i134)
                   {
-                    String _key131; // required
-                    long _val132; // required
-                    _key131 = iprot.readString();
-                    _val132 = iprot.readI64();
-                    _val128.put(_key131, _val132);
+                    String _key135; // required
+                    long _val136; // required
+                    _key135 = iprot.readString();
+                    _val136 = iprot.readI64();
+                    _val132.put(_key135, _val136);
                   }
                   iprot.readMapEnd();
                 }
-                this.emitted.put(_key127, _val128);
+                this.emitted.put(_key131, _val132);
               }
               iprot.readMapEnd();
             }
@@ -511,27 +511,27 @@ public class ExecutorStats implements org.apache.thrift7.TBase<ExecutorStats, Ex
         case 2: // TRANSFERRED
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map133 = iprot.readMapBegin();
-              this.transferred = new HashMap<String,Map<String,Long>>(2*_map133.size);
-              for (int _i134 = 0; _i134 < _map133.size; ++_i134)
+              org.apache.thrift7.protocol.TMap _map137 = iprot.readMapBegin();
+              this.transferred = new HashMap<String,Map<String,Long>>(2*_map137.size);
+              for (int _i138 = 0; _i138 < _map137.size; ++_i138)
               {
-                String _key135; // required
-                Map<String,Long> _val136; // required
-                _key135 = iprot.readString();
+                String _key139; // required
+                Map<String,Long> _val140; // required
+                _key139 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map137 = iprot.readMapBegin();
-                  _val136 = new HashMap<String,Long>(2*_map137.size);
-                  for (int _i138 = 0; _i138 < _map137.size; ++_i138)
+                  org.apache.thrift7.protocol.TMap _map141 = iprot.readMapBegin();
+                  _val140 = new HashMap<String,Long>(2*_map141.size);
+                  for (int _i142 = 0; _i142 < _map141.size; ++_i142)
                   {
-                    String _key139; // required
-                    long _val140; // required
-                    _key139 = iprot.readString();
-                    _val140 = iprot.readI64();
-                    _val136.put(_key139, _val140);
+                    String _key143; // required
+                    long _val144; // required
+                    _key143 = iprot.readString();
+                    _val144 = iprot.readI64();
+                    _val140.put(_key143, _val144);
                   }
                   iprot.readMapEnd();
                 }
-                this.transferred.put(_key135, _val136);
+                this.transferred.put(_key139, _val140);
               }
               iprot.readMapEnd();
             }
@@ -564,15 +564,15 @@ public class ExecutorStats implements org.apache.thrift7.TBase<ExecutorStats, Ex
       oprot.writeFieldBegin(EMITTED_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.emitted.size()));
-        for (Map.Entry<String, Map<String,Long>> _iter141 : this.emitted.entrySet())
+        for (Map.Entry<String, Map<String,Long>> _iter145 : this.emitted.entrySet())
         {
-          oprot.writeString(_iter141.getKey());
+          oprot.writeString(_iter145.getKey());
           {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter141.getValue().size()));
-            for (Map.Entry<String, Long> _iter142 : _iter141.getValue().entrySet())
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter145.getValue().size()));
+            for (Map.Entry<String, Long> _iter146 : _iter145.getValue().entrySet())
             {
-              oprot.writeString(_iter142.getKey());
-              oprot.writeI64(_iter142.getValue());
+              oprot.writeString(_iter146.getKey());
+              oprot.writeI64(_iter146.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -585,15 +585,15 @@ public class ExecutorStats implements org.apache.thrift7.TBase<ExecutorStats, Ex
       oprot.writeFieldBegin(TRANSFERRED_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.transferred.size()));
-        for (Map.Entry<String, Map<String,Long>> _iter143 : this.transferred.entrySet())
+        for (Map.Entry<String, Map<String,Long>> _iter147 : this.transferred.entrySet())
         {
-          oprot.writeString(_iter143.getKey());
+          oprot.writeString(_iter147.getKey());
           {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter143.getValue().size()));
-            for (Map.Entry<String, Long> _iter144 : _iter143.getValue().entrySet())
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter147.getValue().size()));
+            for (Map.Entry<String, Long> _iter148 : _iter147.getValue().entrySet())
             {
-              oprot.writeString(_iter144.getKey());
-              oprot.writeI64(_iter144.getValue());
+              oprot.writeString(_iter148.getKey());
+              oprot.writeI64(_iter148.getValue());
             }
             oprot.writeMapEnd();
           }

--- a/src/jvm/backtype/storm/generated/RebalanceOptions.java
+++ b/src/jvm/backtype/storm/generated/RebalanceOptions.java
@@ -435,15 +435,15 @@ public class RebalanceOptions implements org.apache.thrift7.TBase<RebalanceOptio
         case 3: // NUM_EXECUTORS
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map158 = iprot.readMapBegin();
-              this.num_executors = new HashMap<String,Integer>(2*_map158.size);
-              for (int _i159 = 0; _i159 < _map158.size; ++_i159)
+              org.apache.thrift7.protocol.TMap _map162 = iprot.readMapBegin();
+              this.num_executors = new HashMap<String,Integer>(2*_map162.size);
+              for (int _i163 = 0; _i163 < _map162.size; ++_i163)
               {
-                String _key160; // required
-                int _val161; // required
-                _key160 = iprot.readString();
-                _val161 = iprot.readI32();
-                this.num_executors.put(_key160, _val161);
+                String _key164; // required
+                int _val165; // required
+                _key164 = iprot.readString();
+                _val165 = iprot.readI32();
+                this.num_executors.put(_key164, _val165);
               }
               iprot.readMapEnd();
             }
@@ -479,10 +479,10 @@ public class RebalanceOptions implements org.apache.thrift7.TBase<RebalanceOptio
         oprot.writeFieldBegin(NUM_EXECUTORS_FIELD_DESC);
         {
           oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I32, this.num_executors.size()));
-          for (Map.Entry<String, Integer> _iter162 : this.num_executors.entrySet())
+          for (Map.Entry<String, Integer> _iter166 : this.num_executors.entrySet())
           {
-            oprot.writeString(_iter162.getKey());
-            oprot.writeI32(_iter162.getValue());
+            oprot.writeString(_iter166.getKey());
+            oprot.writeI32(_iter166.getValue());
           }
           oprot.writeMapEnd();
         }

--- a/src/jvm/backtype/storm/generated/SpoutStats.java
+++ b/src/jvm/backtype/storm/generated/SpoutStats.java
@@ -518,27 +518,27 @@ public class SpoutStats implements org.apache.thrift7.TBase<SpoutStats, SpoutSta
         case 1: // ACKED
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map95 = iprot.readMapBegin();
-              this.acked = new HashMap<String,Map<String,Long>>(2*_map95.size);
-              for (int _i96 = 0; _i96 < _map95.size; ++_i96)
+              org.apache.thrift7.protocol.TMap _map99 = iprot.readMapBegin();
+              this.acked = new HashMap<String,Map<String,Long>>(2*_map99.size);
+              for (int _i100 = 0; _i100 < _map99.size; ++_i100)
               {
-                String _key97; // required
-                Map<String,Long> _val98; // required
-                _key97 = iprot.readString();
+                String _key101; // required
+                Map<String,Long> _val102; // required
+                _key101 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map99 = iprot.readMapBegin();
-                  _val98 = new HashMap<String,Long>(2*_map99.size);
-                  for (int _i100 = 0; _i100 < _map99.size; ++_i100)
+                  org.apache.thrift7.protocol.TMap _map103 = iprot.readMapBegin();
+                  _val102 = new HashMap<String,Long>(2*_map103.size);
+                  for (int _i104 = 0; _i104 < _map103.size; ++_i104)
                   {
-                    String _key101; // required
-                    long _val102; // required
-                    _key101 = iprot.readString();
-                    _val102 = iprot.readI64();
-                    _val98.put(_key101, _val102);
+                    String _key105; // required
+                    long _val106; // required
+                    _key105 = iprot.readString();
+                    _val106 = iprot.readI64();
+                    _val102.put(_key105, _val106);
                   }
                   iprot.readMapEnd();
                 }
-                this.acked.put(_key97, _val98);
+                this.acked.put(_key101, _val102);
               }
               iprot.readMapEnd();
             }
@@ -549,27 +549,27 @@ public class SpoutStats implements org.apache.thrift7.TBase<SpoutStats, SpoutSta
         case 2: // FAILED
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map103 = iprot.readMapBegin();
-              this.failed = new HashMap<String,Map<String,Long>>(2*_map103.size);
-              for (int _i104 = 0; _i104 < _map103.size; ++_i104)
+              org.apache.thrift7.protocol.TMap _map107 = iprot.readMapBegin();
+              this.failed = new HashMap<String,Map<String,Long>>(2*_map107.size);
+              for (int _i108 = 0; _i108 < _map107.size; ++_i108)
               {
-                String _key105; // required
-                Map<String,Long> _val106; // required
-                _key105 = iprot.readString();
+                String _key109; // required
+                Map<String,Long> _val110; // required
+                _key109 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map107 = iprot.readMapBegin();
-                  _val106 = new HashMap<String,Long>(2*_map107.size);
-                  for (int _i108 = 0; _i108 < _map107.size; ++_i108)
+                  org.apache.thrift7.protocol.TMap _map111 = iprot.readMapBegin();
+                  _val110 = new HashMap<String,Long>(2*_map111.size);
+                  for (int _i112 = 0; _i112 < _map111.size; ++_i112)
                   {
-                    String _key109; // required
-                    long _val110; // required
-                    _key109 = iprot.readString();
-                    _val110 = iprot.readI64();
-                    _val106.put(_key109, _val110);
+                    String _key113; // required
+                    long _val114; // required
+                    _key113 = iprot.readString();
+                    _val114 = iprot.readI64();
+                    _val110.put(_key113, _val114);
                   }
                   iprot.readMapEnd();
                 }
-                this.failed.put(_key105, _val106);
+                this.failed.put(_key109, _val110);
               }
               iprot.readMapEnd();
             }
@@ -580,27 +580,27 @@ public class SpoutStats implements org.apache.thrift7.TBase<SpoutStats, SpoutSta
         case 3: // COMPLETE_MS_AVG
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map111 = iprot.readMapBegin();
-              this.complete_ms_avg = new HashMap<String,Map<String,Double>>(2*_map111.size);
-              for (int _i112 = 0; _i112 < _map111.size; ++_i112)
+              org.apache.thrift7.protocol.TMap _map115 = iprot.readMapBegin();
+              this.complete_ms_avg = new HashMap<String,Map<String,Double>>(2*_map115.size);
+              for (int _i116 = 0; _i116 < _map115.size; ++_i116)
               {
-                String _key113; // required
-                Map<String,Double> _val114; // required
-                _key113 = iprot.readString();
+                String _key117; // required
+                Map<String,Double> _val118; // required
+                _key117 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TMap _map115 = iprot.readMapBegin();
-                  _val114 = new HashMap<String,Double>(2*_map115.size);
-                  for (int _i116 = 0; _i116 < _map115.size; ++_i116)
+                  org.apache.thrift7.protocol.TMap _map119 = iprot.readMapBegin();
+                  _val118 = new HashMap<String,Double>(2*_map119.size);
+                  for (int _i120 = 0; _i120 < _map119.size; ++_i120)
                   {
-                    String _key117; // required
-                    double _val118; // required
-                    _key117 = iprot.readString();
-                    _val118 = iprot.readDouble();
-                    _val114.put(_key117, _val118);
+                    String _key121; // required
+                    double _val122; // required
+                    _key121 = iprot.readString();
+                    _val122 = iprot.readDouble();
+                    _val118.put(_key121, _val122);
                   }
                   iprot.readMapEnd();
                 }
-                this.complete_ms_avg.put(_key113, _val114);
+                this.complete_ms_avg.put(_key117, _val118);
               }
               iprot.readMapEnd();
             }
@@ -625,15 +625,15 @@ public class SpoutStats implements org.apache.thrift7.TBase<SpoutStats, SpoutSta
       oprot.writeFieldBegin(ACKED_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.acked.size()));
-        for (Map.Entry<String, Map<String,Long>> _iter119 : this.acked.entrySet())
+        for (Map.Entry<String, Map<String,Long>> _iter123 : this.acked.entrySet())
         {
-          oprot.writeString(_iter119.getKey());
+          oprot.writeString(_iter123.getKey());
           {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter119.getValue().size()));
-            for (Map.Entry<String, Long> _iter120 : _iter119.getValue().entrySet())
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter123.getValue().size()));
+            for (Map.Entry<String, Long> _iter124 : _iter123.getValue().entrySet())
             {
-              oprot.writeString(_iter120.getKey());
-              oprot.writeI64(_iter120.getValue());
+              oprot.writeString(_iter124.getKey());
+              oprot.writeI64(_iter124.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -646,15 +646,15 @@ public class SpoutStats implements org.apache.thrift7.TBase<SpoutStats, SpoutSta
       oprot.writeFieldBegin(FAILED_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.failed.size()));
-        for (Map.Entry<String, Map<String,Long>> _iter121 : this.failed.entrySet())
+        for (Map.Entry<String, Map<String,Long>> _iter125 : this.failed.entrySet())
         {
-          oprot.writeString(_iter121.getKey());
+          oprot.writeString(_iter125.getKey());
           {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter121.getValue().size()));
-            for (Map.Entry<String, Long> _iter122 : _iter121.getValue().entrySet())
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.I64, _iter125.getValue().size()));
+            for (Map.Entry<String, Long> _iter126 : _iter125.getValue().entrySet())
             {
-              oprot.writeString(_iter122.getKey());
-              oprot.writeI64(_iter122.getValue());
+              oprot.writeString(_iter126.getKey());
+              oprot.writeI64(_iter126.getValue());
             }
             oprot.writeMapEnd();
           }
@@ -667,15 +667,15 @@ public class SpoutStats implements org.apache.thrift7.TBase<SpoutStats, SpoutSta
       oprot.writeFieldBegin(COMPLETE_MS_AVG_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.MAP, this.complete_ms_avg.size()));
-        for (Map.Entry<String, Map<String,Double>> _iter123 : this.complete_ms_avg.entrySet())
+        for (Map.Entry<String, Map<String,Double>> _iter127 : this.complete_ms_avg.entrySet())
         {
-          oprot.writeString(_iter123.getKey());
+          oprot.writeString(_iter127.getKey());
           {
-            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.DOUBLE, _iter123.getValue().size()));
-            for (Map.Entry<String, Double> _iter124 : _iter123.getValue().entrySet())
+            oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.DOUBLE, _iter127.getValue().size()));
+            for (Map.Entry<String, Double> _iter128 : _iter127.getValue().entrySet())
             {
-              oprot.writeString(_iter124.getKey());
-              oprot.writeDouble(_iter124.getValue());
+              oprot.writeString(_iter128.getKey());
+              oprot.writeDouble(_iter128.getValue());
             }
             oprot.writeMapEnd();
           }

--- a/src/jvm/backtype/storm/generated/SupervisorSummary.java
+++ b/src/jvm/backtype/storm/generated/SupervisorSummary.java
@@ -28,12 +28,14 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
   private static final org.apache.thrift7.protocol.TField UPTIME_SECS_FIELD_DESC = new org.apache.thrift7.protocol.TField("uptime_secs", org.apache.thrift7.protocol.TType.I32, (short)2);
   private static final org.apache.thrift7.protocol.TField NUM_WORKERS_FIELD_DESC = new org.apache.thrift7.protocol.TField("num_workers", org.apache.thrift7.protocol.TType.I32, (short)3);
   private static final org.apache.thrift7.protocol.TField NUM_USED_WORKERS_FIELD_DESC = new org.apache.thrift7.protocol.TField("num_used_workers", org.apache.thrift7.protocol.TType.I32, (short)4);
-  private static final org.apache.thrift7.protocol.TField SUPERVISOR_ID_FIELD_DESC = new org.apache.thrift7.protocol.TField("supervisor_id", org.apache.thrift7.protocol.TType.STRING, (short)5);
+  private static final org.apache.thrift7.protocol.TField WORKER_PIDS_FIELD_DESC = new org.apache.thrift7.protocol.TField("worker_pids", org.apache.thrift7.protocol.TType.LIST, (short)5);
+  private static final org.apache.thrift7.protocol.TField SUPERVISOR_ID_FIELD_DESC = new org.apache.thrift7.protocol.TField("supervisor_id", org.apache.thrift7.protocol.TType.STRING, (short)6);
 
   private String host; // required
   private int uptime_secs; // required
   private int num_workers; // required
   private int num_used_workers; // required
+  private List<Integer> worker_pids; // required
   private String supervisor_id; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
@@ -42,7 +44,8 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     UPTIME_SECS((short)2, "uptime_secs"),
     NUM_WORKERS((short)3, "num_workers"),
     NUM_USED_WORKERS((short)4, "num_used_workers"),
-    SUPERVISOR_ID((short)5, "supervisor_id");
+    WORKER_PIDS((short)5, "worker_pids"),
+    SUPERVISOR_ID((short)6, "supervisor_id");
 
     private static final Map<String, _Fields> byName = new HashMap<String, _Fields>();
 
@@ -65,7 +68,9 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
           return NUM_WORKERS;
         case 4: // NUM_USED_WORKERS
           return NUM_USED_WORKERS;
-        case 5: // SUPERVISOR_ID
+        case 5: // WORKER_PIDS
+          return WORKER_PIDS;
+        case 6: // SUPERVISOR_ID
           return SUPERVISOR_ID;
         default:
           return null;
@@ -123,6 +128,9 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
         new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.I32)));
     tmpMap.put(_Fields.NUM_USED_WORKERS, new org.apache.thrift7.meta_data.FieldMetaData("num_used_workers", org.apache.thrift7.TFieldRequirementType.REQUIRED, 
         new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.I32)));
+    tmpMap.put(_Fields.WORKER_PIDS, new org.apache.thrift7.meta_data.FieldMetaData("worker_pids", org.apache.thrift7.TFieldRequirementType.REQUIRED, 
+        new org.apache.thrift7.meta_data.ListMetaData(org.apache.thrift7.protocol.TType.LIST, 
+            new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.I32))));
     tmpMap.put(_Fields.SUPERVISOR_ID, new org.apache.thrift7.meta_data.FieldMetaData("supervisor_id", org.apache.thrift7.TFieldRequirementType.REQUIRED, 
         new org.apache.thrift7.meta_data.FieldValueMetaData(org.apache.thrift7.protocol.TType.STRING)));
     metaDataMap = Collections.unmodifiableMap(tmpMap);
@@ -137,6 +145,7 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     int uptime_secs,
     int num_workers,
     int num_used_workers,
+    List<Integer> worker_pids,
     String supervisor_id)
   {
     this();
@@ -147,6 +156,7 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     set_num_workers_isSet(true);
     this.num_used_workers = num_used_workers;
     set_num_used_workers_isSet(true);
+    this.worker_pids = worker_pids;
     this.supervisor_id = supervisor_id;
   }
 
@@ -162,6 +172,13 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     this.uptime_secs = other.uptime_secs;
     this.num_workers = other.num_workers;
     this.num_used_workers = other.num_used_workers;
+    if (other.is_set_worker_pids()) {
+      List<Integer> __this__worker_pids = new ArrayList<Integer>();
+      for (Integer other_element : other.worker_pids) {
+        __this__worker_pids.add(other_element);
+      }
+      this.worker_pids = __this__worker_pids;
+    }
     if (other.is_set_supervisor_id()) {
       this.supervisor_id = other.supervisor_id;
     }
@@ -180,6 +197,7 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     this.num_workers = 0;
     set_num_used_workers_isSet(false);
     this.num_used_workers = 0;
+    this.worker_pids = null;
     this.supervisor_id = null;
   }
 
@@ -272,6 +290,44 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     __isset_bit_vector.set(__NUM_USED_WORKERS_ISSET_ID, value);
   }
 
+  public int get_worker_pids_size() {
+    return (this.worker_pids == null) ? 0 : this.worker_pids.size();
+  }
+
+  public java.util.Iterator<Integer> get_worker_pids_iterator() {
+    return (this.worker_pids == null) ? null : this.worker_pids.iterator();
+  }
+
+  public void add_to_worker_pids(int elem) {
+    if (this.worker_pids == null) {
+      this.worker_pids = new ArrayList<Integer>();
+    }
+    this.worker_pids.add(elem);
+  }
+
+  public List<Integer> get_worker_pids() {
+    return this.worker_pids;
+  }
+
+  public void set_worker_pids(List<Integer> worker_pids) {
+    this.worker_pids = worker_pids;
+  }
+
+  public void unset_worker_pids() {
+    this.worker_pids = null;
+  }
+
+  /** Returns true if field worker_pids is set (has been assigned a value) and false otherwise */
+  public boolean is_set_worker_pids() {
+    return this.worker_pids != null;
+  }
+
+  public void set_worker_pids_isSet(boolean value) {
+    if (!value) {
+      this.worker_pids = null;
+    }
+  }
+
   public String get_supervisor_id() {
     return this.supervisor_id;
   }
@@ -329,6 +385,14 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
       }
       break;
 
+    case WORKER_PIDS:
+      if (value == null) {
+        unset_worker_pids();
+      } else {
+        set_worker_pids((List<Integer>)value);
+      }
+      break;
+
     case SUPERVISOR_ID:
       if (value == null) {
         unset_supervisor_id();
@@ -354,6 +418,9 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     case NUM_USED_WORKERS:
       return Integer.valueOf(get_num_used_workers());
 
+    case WORKER_PIDS:
+      return get_worker_pids();
+
     case SUPERVISOR_ID:
       return get_supervisor_id();
 
@@ -376,6 +443,8 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
       return is_set_num_workers();
     case NUM_USED_WORKERS:
       return is_set_num_used_workers();
+    case WORKER_PIDS:
+      return is_set_worker_pids();
     case SUPERVISOR_ID:
       return is_set_supervisor_id();
     }
@@ -431,6 +500,15 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
         return false;
     }
 
+    boolean this_present_worker_pids = true && this.is_set_worker_pids();
+    boolean that_present_worker_pids = true && that.is_set_worker_pids();
+    if (this_present_worker_pids || that_present_worker_pids) {
+      if (!(this_present_worker_pids && that_present_worker_pids))
+        return false;
+      if (!this.worker_pids.equals(that.worker_pids))
+        return false;
+    }
+
     boolean this_present_supervisor_id = true && this.is_set_supervisor_id();
     boolean that_present_supervisor_id = true && that.is_set_supervisor_id();
     if (this_present_supervisor_id || that_present_supervisor_id) {
@@ -466,6 +544,11 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     builder.append(present_num_used_workers);
     if (present_num_used_workers)
       builder.append(num_used_workers);
+
+    boolean present_worker_pids = true && (is_set_worker_pids());
+    builder.append(present_worker_pids);
+    if (present_worker_pids)
+      builder.append(worker_pids);
 
     boolean present_supervisor_id = true && (is_set_supervisor_id());
     builder.append(present_supervisor_id);
@@ -519,6 +602,16 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     }
     if (is_set_num_used_workers()) {
       lastComparison = org.apache.thrift7.TBaseHelper.compareTo(this.num_used_workers, typedOther.num_used_workers);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = Boolean.valueOf(is_set_worker_pids()).compareTo(typedOther.is_set_worker_pids());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (is_set_worker_pids()) {
+      lastComparison = org.apache.thrift7.TBaseHelper.compareTo(this.worker_pids, typedOther.worker_pids);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -581,7 +674,24 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
             org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
           }
           break;
-        case 5: // SUPERVISOR_ID
+        case 5: // WORKER_PIDS
+          if (field.type == org.apache.thrift7.protocol.TType.LIST) {
+            {
+              org.apache.thrift7.protocol.TList _list37 = iprot.readListBegin();
+              this.worker_pids = new ArrayList<Integer>(_list37.size);
+              for (int _i38 = 0; _i38 < _list37.size; ++_i38)
+              {
+                int _elem39; // required
+                _elem39 = iprot.readI32();
+                this.worker_pids.add(_elem39);
+              }
+              iprot.readListEnd();
+            }
+          } else { 
+            org.apache.thrift7.protocol.TProtocolUtil.skip(iprot, field.type);
+          }
+          break;
+        case 6: // SUPERVISOR_ID
           if (field.type == org.apache.thrift7.protocol.TType.STRING) {
             this.supervisor_id = iprot.readString();
           } else { 
@@ -615,6 +725,18 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     oprot.writeFieldBegin(NUM_USED_WORKERS_FIELD_DESC);
     oprot.writeI32(this.num_used_workers);
     oprot.writeFieldEnd();
+    if (this.worker_pids != null) {
+      oprot.writeFieldBegin(WORKER_PIDS_FIELD_DESC);
+      {
+        oprot.writeListBegin(new org.apache.thrift7.protocol.TList(org.apache.thrift7.protocol.TType.I32, this.worker_pids.size()));
+        for (int _iter40 : this.worker_pids)
+        {
+          oprot.writeI32(_iter40);
+        }
+        oprot.writeListEnd();
+      }
+      oprot.writeFieldEnd();
+    }
     if (this.supervisor_id != null) {
       oprot.writeFieldBegin(SUPERVISOR_ID_FIELD_DESC);
       oprot.writeString(this.supervisor_id);
@@ -649,6 +771,14 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
     sb.append(this.num_used_workers);
     first = false;
     if (!first) sb.append(", ");
+    sb.append("worker_pids:");
+    if (this.worker_pids == null) {
+      sb.append("null");
+    } else {
+      sb.append(this.worker_pids);
+    }
+    first = false;
+    if (!first) sb.append(", ");
     sb.append("supervisor_id:");
     if (this.supervisor_id == null) {
       sb.append("null");
@@ -676,6 +806,10 @@ public class SupervisorSummary implements org.apache.thrift7.TBase<SupervisorSum
 
     if (!is_set_num_used_workers()) {
       throw new org.apache.thrift7.protocol.TProtocolException("Required field 'num_used_workers' is unset! Struct:" + toString());
+    }
+
+    if (!is_set_worker_pids()) {
+      throw new org.apache.thrift7.protocol.TProtocolException("Required field 'worker_pids' is unset! Struct:" + toString());
     }
 
     if (!is_set_supervisor_id()) {

--- a/src/jvm/backtype/storm/generated/TopologyInfo.java
+++ b/src/jvm/backtype/storm/generated/TopologyInfo.java
@@ -697,14 +697,14 @@ public class TopologyInfo implements org.apache.thrift7.TBase<TopologyInfo, Topo
         case 4: // EXECUTORS
           if (field.type == org.apache.thrift7.protocol.TType.LIST) {
             {
-              org.apache.thrift7.protocol.TList _list145 = iprot.readListBegin();
-              this.executors = new ArrayList<ExecutorSummary>(_list145.size);
-              for (int _i146 = 0; _i146 < _list145.size; ++_i146)
+              org.apache.thrift7.protocol.TList _list149 = iprot.readListBegin();
+              this.executors = new ArrayList<ExecutorSummary>(_list149.size);
+              for (int _i150 = 0; _i150 < _list149.size; ++_i150)
               {
-                ExecutorSummary _elem147; // required
-                _elem147 = new ExecutorSummary();
-                _elem147.read(iprot);
-                this.executors.add(_elem147);
+                ExecutorSummary _elem151; // required
+                _elem151 = new ExecutorSummary();
+                _elem151.read(iprot);
+                this.executors.add(_elem151);
               }
               iprot.readListEnd();
             }
@@ -722,26 +722,26 @@ public class TopologyInfo implements org.apache.thrift7.TBase<TopologyInfo, Topo
         case 6: // ERRORS
           if (field.type == org.apache.thrift7.protocol.TType.MAP) {
             {
-              org.apache.thrift7.protocol.TMap _map148 = iprot.readMapBegin();
-              this.errors = new HashMap<String,List<ErrorInfo>>(2*_map148.size);
-              for (int _i149 = 0; _i149 < _map148.size; ++_i149)
+              org.apache.thrift7.protocol.TMap _map152 = iprot.readMapBegin();
+              this.errors = new HashMap<String,List<ErrorInfo>>(2*_map152.size);
+              for (int _i153 = 0; _i153 < _map152.size; ++_i153)
               {
-                String _key150; // required
-                List<ErrorInfo> _val151; // required
-                _key150 = iprot.readString();
+                String _key154; // required
+                List<ErrorInfo> _val155; // required
+                _key154 = iprot.readString();
                 {
-                  org.apache.thrift7.protocol.TList _list152 = iprot.readListBegin();
-                  _val151 = new ArrayList<ErrorInfo>(_list152.size);
-                  for (int _i153 = 0; _i153 < _list152.size; ++_i153)
+                  org.apache.thrift7.protocol.TList _list156 = iprot.readListBegin();
+                  _val155 = new ArrayList<ErrorInfo>(_list156.size);
+                  for (int _i157 = 0; _i157 < _list156.size; ++_i157)
                   {
-                    ErrorInfo _elem154; // required
-                    _elem154 = new ErrorInfo();
-                    _elem154.read(iprot);
-                    _val151.add(_elem154);
+                    ErrorInfo _elem158; // required
+                    _elem158 = new ErrorInfo();
+                    _elem158.read(iprot);
+                    _val155.add(_elem158);
                   }
                   iprot.readListEnd();
                 }
-                this.errors.put(_key150, _val151);
+                this.errors.put(_key154, _val155);
               }
               iprot.readMapEnd();
             }
@@ -779,9 +779,9 @@ public class TopologyInfo implements org.apache.thrift7.TBase<TopologyInfo, Topo
       oprot.writeFieldBegin(EXECUTORS_FIELD_DESC);
       {
         oprot.writeListBegin(new org.apache.thrift7.protocol.TList(org.apache.thrift7.protocol.TType.STRUCT, this.executors.size()));
-        for (ExecutorSummary _iter155 : this.executors)
+        for (ExecutorSummary _iter159 : this.executors)
         {
-          _iter155.write(oprot);
+          _iter159.write(oprot);
         }
         oprot.writeListEnd();
       }
@@ -796,14 +796,14 @@ public class TopologyInfo implements org.apache.thrift7.TBase<TopologyInfo, Topo
       oprot.writeFieldBegin(ERRORS_FIELD_DESC);
       {
         oprot.writeMapBegin(new org.apache.thrift7.protocol.TMap(org.apache.thrift7.protocol.TType.STRING, org.apache.thrift7.protocol.TType.LIST, this.errors.size()));
-        for (Map.Entry<String, List<ErrorInfo>> _iter156 : this.errors.entrySet())
+        for (Map.Entry<String, List<ErrorInfo>> _iter160 : this.errors.entrySet())
         {
-          oprot.writeString(_iter156.getKey());
+          oprot.writeString(_iter160.getKey());
           {
-            oprot.writeListBegin(new org.apache.thrift7.protocol.TList(org.apache.thrift7.protocol.TType.STRUCT, _iter156.getValue().size()));
-            for (ErrorInfo _iter157 : _iter156.getValue())
+            oprot.writeListBegin(new org.apache.thrift7.protocol.TList(org.apache.thrift7.protocol.TType.STRUCT, _iter160.getValue().size()));
+            for (ErrorInfo _iter161 : _iter160.getValue())
             {
-              _iter157.write(oprot);
+              _iter161.write(oprot);
             }
             oprot.writeListEnd();
           }

--- a/src/py/storm/ttypes.py
+++ b/src/py/storm/ttypes.py
@@ -1631,6 +1631,7 @@ class SupervisorSummary:
    - uptime_secs
    - num_workers
    - num_used_workers
+   - worker_pids
    - supervisor_id
   """
 
@@ -1640,17 +1641,19 @@ class SupervisorSummary:
     (2, TType.I32, 'uptime_secs', None, None, ), # 2
     (3, TType.I32, 'num_workers', None, None, ), # 3
     (4, TType.I32, 'num_used_workers', None, None, ), # 4
-    (5, TType.STRING, 'supervisor_id', None, None, ), # 5
+    (5, TType.LIST, 'worker_pids', (TType.I32,None), None, ), # 5
+    (6, TType.STRING, 'supervisor_id', None, None, ), # 6
   )
 
   def __hash__(self):
-    return 0 + hash(self.host) + hash(self.uptime_secs) + hash(self.num_workers) + hash(self.num_used_workers) + hash(self.supervisor_id)
+    return 0 + hash(self.host) + hash(self.uptime_secs) + hash(self.num_workers) + hash(self.num_used_workers) + hash(self.worker_pids) + hash(self.supervisor_id)
 
-  def __init__(self, host=None, uptime_secs=None, num_workers=None, num_used_workers=None, supervisor_id=None,):
+  def __init__(self, host=None, uptime_secs=None, num_workers=None, num_used_workers=None, worker_pids=None, supervisor_id=None,):
     self.host = host
     self.uptime_secs = uptime_secs
     self.num_workers = num_workers
     self.num_used_workers = num_used_workers
+    self.worker_pids = worker_pids
     self.supervisor_id = supervisor_id
 
   def read(self, iprot):
@@ -1683,6 +1686,16 @@ class SupervisorSummary:
         else:
           iprot.skip(ftype)
       elif fid == 5:
+        if ftype == TType.LIST:
+          self.worker_pids = []
+          (_etype69, _size66) = iprot.readListBegin()
+          for _i70 in xrange(_size66):
+            _elem71 = iprot.readI32();
+            self.worker_pids.append(_elem71)
+          iprot.readListEnd()
+        else:
+          iprot.skip(ftype)
+      elif fid == 6:
         if ftype == TType.STRING:
           self.supervisor_id = iprot.readString().decode('utf-8')
         else:
@@ -1713,8 +1726,15 @@ class SupervisorSummary:
       oprot.writeFieldBegin('num_used_workers', TType.I32, 4)
       oprot.writeI32(self.num_used_workers)
       oprot.writeFieldEnd()
+    if self.worker_pids is not None:
+      oprot.writeFieldBegin('worker_pids', TType.LIST, 5)
+      oprot.writeListBegin(TType.I32, len(self.worker_pids))
+      for iter72 in self.worker_pids:
+        oprot.writeI32(iter72)
+      oprot.writeListEnd()
+      oprot.writeFieldEnd()
     if self.supervisor_id is not None:
-      oprot.writeFieldBegin('supervisor_id', TType.STRING, 5)
+      oprot.writeFieldBegin('supervisor_id', TType.STRING, 6)
       oprot.writeString(self.supervisor_id.encode('utf-8'))
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -1729,6 +1749,8 @@ class SupervisorSummary:
       raise TProtocol.TProtocolException(message='Required field num_workers is unset!')
     if self.num_used_workers is None:
       raise TProtocol.TProtocolException(message='Required field num_used_workers is unset!')
+    if self.worker_pids is None:
+      raise TProtocol.TProtocolException(message='Required field worker_pids is unset!')
     if self.supervisor_id is None:
       raise TProtocol.TProtocolException(message='Required field supervisor_id is unset!')
     return
@@ -1780,11 +1802,11 @@ class ClusterSummary:
       if fid == 1:
         if ftype == TType.LIST:
           self.supervisors = []
-          (_etype69, _size66) = iprot.readListBegin()
-          for _i70 in xrange(_size66):
-            _elem71 = SupervisorSummary()
-            _elem71.read(iprot)
-            self.supervisors.append(_elem71)
+          (_etype76, _size73) = iprot.readListBegin()
+          for _i77 in xrange(_size73):
+            _elem78 = SupervisorSummary()
+            _elem78.read(iprot)
+            self.supervisors.append(_elem78)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1796,11 +1818,11 @@ class ClusterSummary:
       elif fid == 3:
         if ftype == TType.LIST:
           self.topologies = []
-          (_etype75, _size72) = iprot.readListBegin()
-          for _i76 in xrange(_size72):
-            _elem77 = TopologySummary()
-            _elem77.read(iprot)
-            self.topologies.append(_elem77)
+          (_etype82, _size79) = iprot.readListBegin()
+          for _i83 in xrange(_size79):
+            _elem84 = TopologySummary()
+            _elem84.read(iprot)
+            self.topologies.append(_elem84)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -1817,8 +1839,8 @@ class ClusterSummary:
     if self.supervisors is not None:
       oprot.writeFieldBegin('supervisors', TType.LIST, 1)
       oprot.writeListBegin(TType.STRUCT, len(self.supervisors))
-      for iter78 in self.supervisors:
-        iter78.write(oprot)
+      for iter85 in self.supervisors:
+        iter85.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.nimbus_uptime_secs is not None:
@@ -1828,8 +1850,8 @@ class ClusterSummary:
     if self.topologies is not None:
       oprot.writeFieldBegin('topologies', TType.LIST, 3)
       oprot.writeListBegin(TType.STRUCT, len(self.topologies))
-      for iter79 in self.topologies:
-        iter79.write(oprot)
+      for iter86 in self.topologies:
+        iter86.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()
@@ -1976,90 +1998,90 @@ class BoltStats:
       if fid == 1:
         if ftype == TType.MAP:
           self.acked = {}
-          (_ktype81, _vtype82, _size80 ) = iprot.readMapBegin() 
-          for _i84 in xrange(_size80):
-            _key85 = iprot.readString().decode('utf-8')
-            _val86 = {}
-            (_ktype88, _vtype89, _size87 ) = iprot.readMapBegin() 
-            for _i91 in xrange(_size87):
-              _key92 = GlobalStreamId()
-              _key92.read(iprot)
-              _val93 = iprot.readI64();
-              _val86[_key92] = _val93
+          (_ktype88, _vtype89, _size87 ) = iprot.readMapBegin() 
+          for _i91 in xrange(_size87):
+            _key92 = iprot.readString().decode('utf-8')
+            _val93 = {}
+            (_ktype95, _vtype96, _size94 ) = iprot.readMapBegin() 
+            for _i98 in xrange(_size94):
+              _key99 = GlobalStreamId()
+              _key99.read(iprot)
+              _val100 = iprot.readI64();
+              _val93[_key99] = _val100
             iprot.readMapEnd()
-            self.acked[_key85] = _val86
+            self.acked[_key92] = _val93
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.MAP:
           self.failed = {}
-          (_ktype95, _vtype96, _size94 ) = iprot.readMapBegin() 
-          for _i98 in xrange(_size94):
-            _key99 = iprot.readString().decode('utf-8')
-            _val100 = {}
-            (_ktype102, _vtype103, _size101 ) = iprot.readMapBegin() 
-            for _i105 in xrange(_size101):
-              _key106 = GlobalStreamId()
-              _key106.read(iprot)
-              _val107 = iprot.readI64();
-              _val100[_key106] = _val107
+          (_ktype102, _vtype103, _size101 ) = iprot.readMapBegin() 
+          for _i105 in xrange(_size101):
+            _key106 = iprot.readString().decode('utf-8')
+            _val107 = {}
+            (_ktype109, _vtype110, _size108 ) = iprot.readMapBegin() 
+            for _i112 in xrange(_size108):
+              _key113 = GlobalStreamId()
+              _key113.read(iprot)
+              _val114 = iprot.readI64();
+              _val107[_key113] = _val114
             iprot.readMapEnd()
-            self.failed[_key99] = _val100
+            self.failed[_key106] = _val107
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 3:
         if ftype == TType.MAP:
           self.process_ms_avg = {}
-          (_ktype109, _vtype110, _size108 ) = iprot.readMapBegin() 
-          for _i112 in xrange(_size108):
-            _key113 = iprot.readString().decode('utf-8')
-            _val114 = {}
-            (_ktype116, _vtype117, _size115 ) = iprot.readMapBegin() 
-            for _i119 in xrange(_size115):
-              _key120 = GlobalStreamId()
-              _key120.read(iprot)
-              _val121 = iprot.readDouble();
-              _val114[_key120] = _val121
+          (_ktype116, _vtype117, _size115 ) = iprot.readMapBegin() 
+          for _i119 in xrange(_size115):
+            _key120 = iprot.readString().decode('utf-8')
+            _val121 = {}
+            (_ktype123, _vtype124, _size122 ) = iprot.readMapBegin() 
+            for _i126 in xrange(_size122):
+              _key127 = GlobalStreamId()
+              _key127.read(iprot)
+              _val128 = iprot.readDouble();
+              _val121[_key127] = _val128
             iprot.readMapEnd()
-            self.process_ms_avg[_key113] = _val114
+            self.process_ms_avg[_key120] = _val121
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 4:
         if ftype == TType.MAP:
           self.executed = {}
-          (_ktype123, _vtype124, _size122 ) = iprot.readMapBegin() 
-          for _i126 in xrange(_size122):
-            _key127 = iprot.readString().decode('utf-8')
-            _val128 = {}
-            (_ktype130, _vtype131, _size129 ) = iprot.readMapBegin() 
-            for _i133 in xrange(_size129):
-              _key134 = GlobalStreamId()
-              _key134.read(iprot)
-              _val135 = iprot.readI64();
-              _val128[_key134] = _val135
+          (_ktype130, _vtype131, _size129 ) = iprot.readMapBegin() 
+          for _i133 in xrange(_size129):
+            _key134 = iprot.readString().decode('utf-8')
+            _val135 = {}
+            (_ktype137, _vtype138, _size136 ) = iprot.readMapBegin() 
+            for _i140 in xrange(_size136):
+              _key141 = GlobalStreamId()
+              _key141.read(iprot)
+              _val142 = iprot.readI64();
+              _val135[_key141] = _val142
             iprot.readMapEnd()
-            self.executed[_key127] = _val128
+            self.executed[_key134] = _val135
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 5:
         if ftype == TType.MAP:
           self.execute_ms_avg = {}
-          (_ktype137, _vtype138, _size136 ) = iprot.readMapBegin() 
-          for _i140 in xrange(_size136):
-            _key141 = iprot.readString().decode('utf-8')
-            _val142 = {}
-            (_ktype144, _vtype145, _size143 ) = iprot.readMapBegin() 
-            for _i147 in xrange(_size143):
-              _key148 = GlobalStreamId()
-              _key148.read(iprot)
-              _val149 = iprot.readDouble();
-              _val142[_key148] = _val149
+          (_ktype144, _vtype145, _size143 ) = iprot.readMapBegin() 
+          for _i147 in xrange(_size143):
+            _key148 = iprot.readString().decode('utf-8')
+            _val149 = {}
+            (_ktype151, _vtype152, _size150 ) = iprot.readMapBegin() 
+            for _i154 in xrange(_size150):
+              _key155 = GlobalStreamId()
+              _key155.read(iprot)
+              _val156 = iprot.readDouble();
+              _val149[_key155] = _val156
             iprot.readMapEnd()
-            self.execute_ms_avg[_key141] = _val142
+            self.execute_ms_avg[_key148] = _val149
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -2076,60 +2098,60 @@ class BoltStats:
     if self.acked is not None:
       oprot.writeFieldBegin('acked', TType.MAP, 1)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.acked))
-      for kiter150,viter151 in self.acked.items():
-        oprot.writeString(kiter150.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRUCT, TType.I64, len(viter151))
-        for kiter152,viter153 in viter151.items():
-          kiter152.write(oprot)
-          oprot.writeI64(viter153)
+      for kiter157,viter158 in self.acked.items():
+        oprot.writeString(kiter157.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRUCT, TType.I64, len(viter158))
+        for kiter159,viter160 in viter158.items():
+          kiter159.write(oprot)
+          oprot.writeI64(viter160)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.failed is not None:
       oprot.writeFieldBegin('failed', TType.MAP, 2)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.failed))
-      for kiter154,viter155 in self.failed.items():
-        oprot.writeString(kiter154.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRUCT, TType.I64, len(viter155))
-        for kiter156,viter157 in viter155.items():
-          kiter156.write(oprot)
-          oprot.writeI64(viter157)
+      for kiter161,viter162 in self.failed.items():
+        oprot.writeString(kiter161.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRUCT, TType.I64, len(viter162))
+        for kiter163,viter164 in viter162.items():
+          kiter163.write(oprot)
+          oprot.writeI64(viter164)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.process_ms_avg is not None:
       oprot.writeFieldBegin('process_ms_avg', TType.MAP, 3)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.process_ms_avg))
-      for kiter158,viter159 in self.process_ms_avg.items():
-        oprot.writeString(kiter158.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRUCT, TType.DOUBLE, len(viter159))
-        for kiter160,viter161 in viter159.items():
-          kiter160.write(oprot)
-          oprot.writeDouble(viter161)
+      for kiter165,viter166 in self.process_ms_avg.items():
+        oprot.writeString(kiter165.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRUCT, TType.DOUBLE, len(viter166))
+        for kiter167,viter168 in viter166.items():
+          kiter167.write(oprot)
+          oprot.writeDouble(viter168)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.executed is not None:
       oprot.writeFieldBegin('executed', TType.MAP, 4)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.executed))
-      for kiter162,viter163 in self.executed.items():
-        oprot.writeString(kiter162.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRUCT, TType.I64, len(viter163))
-        for kiter164,viter165 in viter163.items():
-          kiter164.write(oprot)
-          oprot.writeI64(viter165)
+      for kiter169,viter170 in self.executed.items():
+        oprot.writeString(kiter169.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRUCT, TType.I64, len(viter170))
+        for kiter171,viter172 in viter170.items():
+          kiter171.write(oprot)
+          oprot.writeI64(viter172)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.execute_ms_avg is not None:
       oprot.writeFieldBegin('execute_ms_avg', TType.MAP, 5)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.execute_ms_avg))
-      for kiter166,viter167 in self.execute_ms_avg.items():
-        oprot.writeString(kiter166.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRUCT, TType.DOUBLE, len(viter167))
-        for kiter168,viter169 in viter167.items():
-          kiter168.write(oprot)
-          oprot.writeDouble(viter169)
+      for kiter173,viter174 in self.execute_ms_avg.items():
+        oprot.writeString(kiter173.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRUCT, TType.DOUBLE, len(viter174))
+        for kiter175,viter176 in viter174.items():
+          kiter175.write(oprot)
+          oprot.writeDouble(viter176)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
@@ -2196,51 +2218,51 @@ class SpoutStats:
       if fid == 1:
         if ftype == TType.MAP:
           self.acked = {}
-          (_ktype171, _vtype172, _size170 ) = iprot.readMapBegin() 
-          for _i174 in xrange(_size170):
-            _key175 = iprot.readString().decode('utf-8')
-            _val176 = {}
-            (_ktype178, _vtype179, _size177 ) = iprot.readMapBegin() 
-            for _i181 in xrange(_size177):
-              _key182 = iprot.readString().decode('utf-8')
-              _val183 = iprot.readI64();
-              _val176[_key182] = _val183
+          (_ktype178, _vtype179, _size177 ) = iprot.readMapBegin() 
+          for _i181 in xrange(_size177):
+            _key182 = iprot.readString().decode('utf-8')
+            _val183 = {}
+            (_ktype185, _vtype186, _size184 ) = iprot.readMapBegin() 
+            for _i188 in xrange(_size184):
+              _key189 = iprot.readString().decode('utf-8')
+              _val190 = iprot.readI64();
+              _val183[_key189] = _val190
             iprot.readMapEnd()
-            self.acked[_key175] = _val176
+            self.acked[_key182] = _val183
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.MAP:
           self.failed = {}
-          (_ktype185, _vtype186, _size184 ) = iprot.readMapBegin() 
-          for _i188 in xrange(_size184):
-            _key189 = iprot.readString().decode('utf-8')
-            _val190 = {}
-            (_ktype192, _vtype193, _size191 ) = iprot.readMapBegin() 
-            for _i195 in xrange(_size191):
-              _key196 = iprot.readString().decode('utf-8')
-              _val197 = iprot.readI64();
-              _val190[_key196] = _val197
+          (_ktype192, _vtype193, _size191 ) = iprot.readMapBegin() 
+          for _i195 in xrange(_size191):
+            _key196 = iprot.readString().decode('utf-8')
+            _val197 = {}
+            (_ktype199, _vtype200, _size198 ) = iprot.readMapBegin() 
+            for _i202 in xrange(_size198):
+              _key203 = iprot.readString().decode('utf-8')
+              _val204 = iprot.readI64();
+              _val197[_key203] = _val204
             iprot.readMapEnd()
-            self.failed[_key189] = _val190
+            self.failed[_key196] = _val197
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 3:
         if ftype == TType.MAP:
           self.complete_ms_avg = {}
-          (_ktype199, _vtype200, _size198 ) = iprot.readMapBegin() 
-          for _i202 in xrange(_size198):
-            _key203 = iprot.readString().decode('utf-8')
-            _val204 = {}
-            (_ktype206, _vtype207, _size205 ) = iprot.readMapBegin() 
-            for _i209 in xrange(_size205):
-              _key210 = iprot.readString().decode('utf-8')
-              _val211 = iprot.readDouble();
-              _val204[_key210] = _val211
+          (_ktype206, _vtype207, _size205 ) = iprot.readMapBegin() 
+          for _i209 in xrange(_size205):
+            _key210 = iprot.readString().decode('utf-8')
+            _val211 = {}
+            (_ktype213, _vtype214, _size212 ) = iprot.readMapBegin() 
+            for _i216 in xrange(_size212):
+              _key217 = iprot.readString().decode('utf-8')
+              _val218 = iprot.readDouble();
+              _val211[_key217] = _val218
             iprot.readMapEnd()
-            self.complete_ms_avg[_key203] = _val204
+            self.complete_ms_avg[_key210] = _val211
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -2257,36 +2279,36 @@ class SpoutStats:
     if self.acked is not None:
       oprot.writeFieldBegin('acked', TType.MAP, 1)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.acked))
-      for kiter212,viter213 in self.acked.items():
-        oprot.writeString(kiter212.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter213))
-        for kiter214,viter215 in viter213.items():
-          oprot.writeString(kiter214.encode('utf-8'))
-          oprot.writeI64(viter215)
+      for kiter219,viter220 in self.acked.items():
+        oprot.writeString(kiter219.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter220))
+        for kiter221,viter222 in viter220.items():
+          oprot.writeString(kiter221.encode('utf-8'))
+          oprot.writeI64(viter222)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.failed is not None:
       oprot.writeFieldBegin('failed', TType.MAP, 2)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.failed))
-      for kiter216,viter217 in self.failed.items():
-        oprot.writeString(kiter216.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter217))
-        for kiter218,viter219 in viter217.items():
-          oprot.writeString(kiter218.encode('utf-8'))
-          oprot.writeI64(viter219)
+      for kiter223,viter224 in self.failed.items():
+        oprot.writeString(kiter223.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter224))
+        for kiter225,viter226 in viter224.items():
+          oprot.writeString(kiter225.encode('utf-8'))
+          oprot.writeI64(viter226)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.complete_ms_avg is not None:
       oprot.writeFieldBegin('complete_ms_avg', TType.MAP, 3)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.complete_ms_avg))
-      for kiter220,viter221 in self.complete_ms_avg.items():
-        oprot.writeString(kiter220.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRING, TType.DOUBLE, len(viter221))
-        for kiter222,viter223 in viter221.items():
-          oprot.writeString(kiter222.encode('utf-8'))
-          oprot.writeDouble(viter223)
+      for kiter227,viter228 in self.complete_ms_avg.items():
+        oprot.writeString(kiter227.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRING, TType.DOUBLE, len(viter228))
+        for kiter229,viter230 in viter228.items():
+          oprot.writeString(kiter229.encode('utf-8'))
+          oprot.writeDouble(viter230)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
@@ -2426,34 +2448,34 @@ class ExecutorStats:
       if fid == 1:
         if ftype == TType.MAP:
           self.emitted = {}
-          (_ktype225, _vtype226, _size224 ) = iprot.readMapBegin() 
-          for _i228 in xrange(_size224):
-            _key229 = iprot.readString().decode('utf-8')
-            _val230 = {}
-            (_ktype232, _vtype233, _size231 ) = iprot.readMapBegin() 
-            for _i235 in xrange(_size231):
-              _key236 = iprot.readString().decode('utf-8')
-              _val237 = iprot.readI64();
-              _val230[_key236] = _val237
+          (_ktype232, _vtype233, _size231 ) = iprot.readMapBegin() 
+          for _i235 in xrange(_size231):
+            _key236 = iprot.readString().decode('utf-8')
+            _val237 = {}
+            (_ktype239, _vtype240, _size238 ) = iprot.readMapBegin() 
+            for _i242 in xrange(_size238):
+              _key243 = iprot.readString().decode('utf-8')
+              _val244 = iprot.readI64();
+              _val237[_key243] = _val244
             iprot.readMapEnd()
-            self.emitted[_key229] = _val230
+            self.emitted[_key236] = _val237
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
       elif fid == 2:
         if ftype == TType.MAP:
           self.transferred = {}
-          (_ktype239, _vtype240, _size238 ) = iprot.readMapBegin() 
-          for _i242 in xrange(_size238):
-            _key243 = iprot.readString().decode('utf-8')
-            _val244 = {}
-            (_ktype246, _vtype247, _size245 ) = iprot.readMapBegin() 
-            for _i249 in xrange(_size245):
-              _key250 = iprot.readString().decode('utf-8')
-              _val251 = iprot.readI64();
-              _val244[_key250] = _val251
+          (_ktype246, _vtype247, _size245 ) = iprot.readMapBegin() 
+          for _i249 in xrange(_size245):
+            _key250 = iprot.readString().decode('utf-8')
+            _val251 = {}
+            (_ktype253, _vtype254, _size252 ) = iprot.readMapBegin() 
+            for _i256 in xrange(_size252):
+              _key257 = iprot.readString().decode('utf-8')
+              _val258 = iprot.readI64();
+              _val251[_key257] = _val258
             iprot.readMapEnd()
-            self.transferred[_key243] = _val244
+            self.transferred[_key250] = _val251
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -2476,24 +2498,24 @@ class ExecutorStats:
     if self.emitted is not None:
       oprot.writeFieldBegin('emitted', TType.MAP, 1)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.emitted))
-      for kiter252,viter253 in self.emitted.items():
-        oprot.writeString(kiter252.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter253))
-        for kiter254,viter255 in viter253.items():
-          oprot.writeString(kiter254.encode('utf-8'))
-          oprot.writeI64(viter255)
+      for kiter259,viter260 in self.emitted.items():
+        oprot.writeString(kiter259.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter260))
+        for kiter261,viter262 in viter260.items():
+          oprot.writeString(kiter261.encode('utf-8'))
+          oprot.writeI64(viter262)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     if self.transferred is not None:
       oprot.writeFieldBegin('transferred', TType.MAP, 2)
       oprot.writeMapBegin(TType.STRING, TType.MAP, len(self.transferred))
-      for kiter256,viter257 in self.transferred.items():
-        oprot.writeString(kiter256.encode('utf-8'))
-        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter257))
-        for kiter258,viter259 in viter257.items():
-          oprot.writeString(kiter258.encode('utf-8'))
-          oprot.writeI64(viter259)
+      for kiter263,viter264 in self.transferred.items():
+        oprot.writeString(kiter263.encode('utf-8'))
+        oprot.writeMapBegin(TType.STRING, TType.I64, len(viter264))
+        for kiter265,viter266 in viter264.items():
+          oprot.writeString(kiter265.encode('utf-8'))
+          oprot.writeI64(viter266)
         oprot.writeMapEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
@@ -2799,11 +2821,11 @@ class TopologyInfo:
       elif fid == 4:
         if ftype == TType.LIST:
           self.executors = []
-          (_etype263, _size260) = iprot.readListBegin()
-          for _i264 in xrange(_size260):
-            _elem265 = ExecutorSummary()
-            _elem265.read(iprot)
-            self.executors.append(_elem265)
+          (_etype270, _size267) = iprot.readListBegin()
+          for _i271 in xrange(_size267):
+            _elem272 = ExecutorSummary()
+            _elem272.read(iprot)
+            self.executors.append(_elem272)
           iprot.readListEnd()
         else:
           iprot.skip(ftype)
@@ -2815,17 +2837,17 @@ class TopologyInfo:
       elif fid == 6:
         if ftype == TType.MAP:
           self.errors = {}
-          (_ktype267, _vtype268, _size266 ) = iprot.readMapBegin() 
-          for _i270 in xrange(_size266):
-            _key271 = iprot.readString().decode('utf-8')
-            _val272 = []
-            (_etype276, _size273) = iprot.readListBegin()
-            for _i277 in xrange(_size273):
-              _elem278 = ErrorInfo()
-              _elem278.read(iprot)
-              _val272.append(_elem278)
+          (_ktype274, _vtype275, _size273 ) = iprot.readMapBegin() 
+          for _i277 in xrange(_size273):
+            _key278 = iprot.readString().decode('utf-8')
+            _val279 = []
+            (_etype283, _size280) = iprot.readListBegin()
+            for _i284 in xrange(_size280):
+              _elem285 = ErrorInfo()
+              _elem285.read(iprot)
+              _val279.append(_elem285)
             iprot.readListEnd()
-            self.errors[_key271] = _val272
+            self.errors[_key278] = _val279
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -2854,8 +2876,8 @@ class TopologyInfo:
     if self.executors is not None:
       oprot.writeFieldBegin('executors', TType.LIST, 4)
       oprot.writeListBegin(TType.STRUCT, len(self.executors))
-      for iter279 in self.executors:
-        iter279.write(oprot)
+      for iter286 in self.executors:
+        iter286.write(oprot)
       oprot.writeListEnd()
       oprot.writeFieldEnd()
     if self.status is not None:
@@ -2865,11 +2887,11 @@ class TopologyInfo:
     if self.errors is not None:
       oprot.writeFieldBegin('errors', TType.MAP, 6)
       oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.errors))
-      for kiter280,viter281 in self.errors.items():
-        oprot.writeString(kiter280.encode('utf-8'))
-        oprot.writeListBegin(TType.STRUCT, len(viter281))
-        for iter282 in viter281:
-          iter282.write(oprot)
+      for kiter287,viter288 in self.errors.items():
+        oprot.writeString(kiter287.encode('utf-8'))
+        oprot.writeListBegin(TType.STRUCT, len(viter288))
+        for iter289 in viter288:
+          iter289.write(oprot)
         oprot.writeListEnd()
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
@@ -3011,11 +3033,11 @@ class RebalanceOptions:
       elif fid == 3:
         if ftype == TType.MAP:
           self.num_executors = {}
-          (_ktype284, _vtype285, _size283 ) = iprot.readMapBegin() 
-          for _i287 in xrange(_size283):
-            _key288 = iprot.readString().decode('utf-8')
-            _val289 = iprot.readI32();
-            self.num_executors[_key288] = _val289
+          (_ktype291, _vtype292, _size290 ) = iprot.readMapBegin() 
+          for _i294 in xrange(_size290):
+            _key295 = iprot.readString().decode('utf-8')
+            _val296 = iprot.readI32();
+            self.num_executors[_key295] = _val296
           iprot.readMapEnd()
         else:
           iprot.skip(ftype)
@@ -3040,9 +3062,9 @@ class RebalanceOptions:
     if self.num_executors is not None:
       oprot.writeFieldBegin('num_executors', TType.MAP, 3)
       oprot.writeMapBegin(TType.STRING, TType.I32, len(self.num_executors))
-      for kiter290,viter291 in self.num_executors.items():
-        oprot.writeString(kiter290.encode('utf-8'))
-        oprot.writeI32(viter291)
+      for kiter297,viter298 in self.num_executors.items():
+        oprot.writeString(kiter297.encode('utf-8'))
+        oprot.writeI32(viter298)
       oprot.writeMapEnd()
       oprot.writeFieldEnd()
     oprot.writeFieldStop()

--- a/src/storm.thrift
+++ b/src/storm.thrift
@@ -123,7 +123,8 @@ struct SupervisorSummary {
   2: required i32 uptime_secs;
   3: required i32 num_workers;
   4: required i32 num_used_workers;
-  5: required string supervisor_id;
+  5: required list<i32> worker_pids;
+  6: required string supervisor_id;
 }
 
 struct ClusterSummary {


### PR DESCRIPTION
This is aimed at issue #418.

One note is that the new [backtype.storm.util/get-process-pid](https://github.com/strongh/storm/blob/supervisor-heartbeat-worker-pids/src/clj/backtype/storm/util.clj#L319]) assumes that the `Process` returned by `backtype.storm.util/launch-process` (ie from a `ProcessBuilder`) is a `UnixProcess`. This should be true for OS X and Linux, but definitely not for Windows- AFAICT there is no good portable way to get the pid from a `Process`. This isn't an issue as long as running a cluster on Windows is a non-goal.

This is my first brush with storm's internals, please let me know if I missed anything!
