### PR TITLE
 Issue #456 worker logging fix

### DIFF
--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -409,6 +409,7 @@
 (defmethod launch-worker
     :distributed [supervisor storm-id port worker-id]
     (let [conf (:conf supervisor)
+          storm-home (System/getProperty "storm.home")
           stormroot (supervisor-stormdist-root conf storm-id)
           stormjar (supervisor-stormjar-path stormroot)
           storm-conf (read-supervisor-storm-conf conf storm-id)
@@ -420,8 +421,8 @@
           command (str "java -server " childopts
                        " -Djava.library.path=" (conf JAVA-LIBRARY-PATH)
                        " -Dlogfile.name=" logfilename
-                       " -Dstorm.home=" (System/getProperty "storm.home")
-                       " -Dlogback.configurationFile=logback/cluster.xml"
+                       " -Dstorm.home=" storm-home
+                       " -Dlogback.configurationFile=" storm-home "/logback/cluster.xml"
                        " -cp " classpath " backtype.storm.daemon.worker "
                        (java.net.URLEncoder/encode storm-id) " " (:assignment-id supervisor)
                        " " port " " worker-id)]

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -1,7 +1,3 @@
-;; Copyright (c) 2013 Yahoo! Inc. All Rights Reserved.
-;; Copyrights licensed under the Eclipse Public License.
-;; See the accompanying LICENSE.html file for terms.
-
 (ns backtype.storm.daemon.supervisor
   (:import [backtype.storm.scheduler ISupervisor])
   (:use [backtype.storm bootstrap])

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -1,3 +1,7 @@
+;; Copyright (c) 2013 Yahoo! Inc. All Rights Reserved.
+;; Copyrights licensed under the Eclipse Public License.
+;; See the accompanying LICENSE.html file for terms.
+
 (ns backtype.storm.daemon.supervisor
   (:import [backtype.storm.scheduler ISupervisor])
   (:use [backtype.storm bootstrap])


### PR DESCRIPTION
This is a fix for Issue #456. It simply adds in storm.home in front of the path to cluster.xml like the storm executable does when launching various processes.
