### PR TITLE
Initialising ReducerAggregator if (when) state is null.

### DIFF
--- a/src/jvm/storm/trident/state/ReducerValueUpdater.java
+++ b/src/jvm/storm/trident/state/ReducerValueUpdater.java
@@ -15,7 +15,7 @@ public class ReducerValueUpdater implements ValueUpdater<Object> {
 
     @Override
     public Object update(Object stored) {
-        Object ret = stored;
+        Object ret = (stored == null) ? this.agg.init() : stored;
         for(TridentTuple t: tuples) {
            ret =  this.agg.reduce(ret, t);
         }


### PR DESCRIPTION
I've updated `ReducerValueUpdater` to initialise its `ReducerAggregator` whenever `stored` is null. This solution assumes that `stored` will only be null the first time `update` is run. Attempts to address nathanmarz/storm#464. (Possibly this solution is a little too dumb/naive?)
[This  problem was discussed on the mailing list](https://groups.google.com/d/topic/storm-user/3kQU_8FO1xg/discussion) 
