### PR TITLE
Have storm fall back to installed storm.yaml.

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -22,10 +22,14 @@ if sys.platform == "cygwin":
 else:
     normclasspath = identity
 
-CONF_DIR = os.path.expanduser("~/.storm")
 STORM_DIR = "/".join(os.path.realpath( __file__ ).split("/")[:-2])
+USER_CONF_DIR = os.path.expanduser("~/.storm")
+CLUSTER_CONF_DIR = STORM_DIR + "/conf"
+if (not os.path.isfile(USER_CONF_DIR + "/storm.yaml")):
+    USER_CONF_DIR = CLUSTER_CONF_DIR
 CONFIG_OPTS = []
 CONFFILE = ""
+
 
 def get_config_opts():
     global CONFIG_OPTS
@@ -73,7 +77,7 @@ def print_localconfvalue(name):
     The local Storm configs are the ones in ~/.storm/storm.yaml merged 
     in with the configs in defaults.yaml.
     """
-    print name + ": " + confvalue(name, [CONF_DIR])
+    print name + ": " + confvalue(name, [USER_CONF_DIR])
 
 def print_remoteconfvalue(name):
     """Syntax: [storm remoteconfvalue conf-name]
@@ -84,7 +88,7 @@ def print_remoteconfvalue(name):
 
     This command must be run on a cluster machine.
     """
-    print name + ": " + confvalue(name, [STORM_DIR + "/conf"])
+    print name + ": " + confvalue(name, [CLUSTER_CONF_DIR])
 
 def parse_args(string):
     r"""Takes a string of whitespace-separated tokens and parses it into a list.
@@ -132,7 +136,7 @@ def jar(jarfile, klass, *args):
     exec_storm_class(
         klass,
         jvmtype="-client",
-        extrajars=[jarfile, CONF_DIR, STORM_DIR + "/bin"],
+        extrajars=[jarfile, USER_CONF_DIR, STORM_DIR + "/bin"],
         args=args,
         jvmopts=["-Dstorm.jar=" + jarfile])
 
@@ -150,7 +154,7 @@ def kill(*args):
         "backtype.storm.command.kill_topology", 
         args=args, 
         jvmtype="-client", 
-        extrajars=[CONF_DIR, STORM_DIR + "/bin"])
+        extrajars=[USER_CONF_DIR, STORM_DIR + "/bin"])
 
 def activate(*args):
     """Syntax: [storm activate topology-name]
@@ -161,7 +165,7 @@ def activate(*args):
         "backtype.storm.command.activate", 
         args=args, 
         jvmtype="-client", 
-        extrajars=[CONF_DIR, STORM_DIR + "/bin"])
+        extrajars=[USER_CONF_DIR, STORM_DIR + "/bin"])
 
 def listtopos(*args):
     """Syntax: [storm list]
@@ -172,7 +176,7 @@ def listtopos(*args):
         "backtype.storm.command.list", 
         args=args, 
         jvmtype="-client", 
-        extrajars=[CONF_DIR, STORM_DIR + "/bin"])
+        extrajars=[USER_CONF_DIR, STORM_DIR + "/bin"])
 
 def deactivate(*args):
     """Syntax: [storm deactivate topology-name]
@@ -183,7 +187,7 @@ def deactivate(*args):
         "backtype.storm.command.deactivate", 
         args=args, 
         jvmtype="-client", 
-        extrajars=[CONF_DIR, STORM_DIR + "/bin"])
+        extrajars=[USER_CONF_DIR, STORM_DIR + "/bin"])
 
 def rebalance(*args):
     """Syntax: [storm rebalance topology-name [-w wait-time-secs] [-n new-num-workers] [-e component=parallelism]*]
@@ -210,7 +214,7 @@ def rebalance(*args):
         "backtype.storm.command.rebalance", 
         args=args, 
         jvmtype="-client", 
-        extrajars=[CONF_DIR, STORM_DIR + "/bin"])
+        extrajars=[USER_CONF_DIR, STORM_DIR + "/bin"])
 
 def shell(resourcesdir, command, *args):
     tmpjarpath = "stormshell" + str(random.randint(0, 10000000)) + ".jar"
@@ -221,7 +225,7 @@ def shell(resourcesdir, command, *args):
         "backtype.storm.command.shell_submission", 
         args=runnerargs, 
         jvmtype="-client", 
-        extrajars=[CONF_DIR],
+        extrajars=[USER_CONF_DIR],
         fork=True)
     os.system("rm " + tmpjarpath)
 
@@ -231,7 +235,7 @@ def repl():
     Opens up a Clojure REPL with the storm jars and configuration 
     on the classpath. Useful for debugging.
     """
-    cppaths = [STORM_DIR + "/conf"]
+    cppaths = [CLUSTER_CONF_DIR]
     exec_storm_class("clojure.lang.Repl", jvmtype="-client", extrajars=cppaths)
 
 def nimbus(klass="backtype.storm.daemon.nimbus"):
@@ -243,7 +247,7 @@ def nimbus(klass="backtype.storm.daemon.nimbus"):
     See Setting up a Storm cluster for more information.
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
-    cppaths = [STORM_DIR + "/conf"]
+    cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("nimbus.childopts", cppaths)) + [
         "-Dlogfile.name=nimbus.log",
         "-Dlogback.configurationFile=" + STORM_DIR + "/logback/cluster.xml",
@@ -263,7 +267,7 @@ def supervisor(klass="backtype.storm.daemon.supervisor"):
     See Setting up a Storm cluster for more information.
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
-    cppaths = [STORM_DIR + "/conf"]
+    cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("supervisor.childopts", cppaths)) + [
         "-Dlogfile.name=supervisor.log",
         "-Dlogback.configurationFile=" + STORM_DIR + "/logback/cluster.xml",
@@ -284,7 +288,7 @@ def ui():
     See Setting up a Storm cluster for more information.
     (https://github.com/nathanmarz/storm/wiki/Setting-up-a-Storm-cluster)
     """
-    cppaths = [STORM_DIR + "/conf"]
+    cppaths = [CLUSTER_CONF_DIR]
     jvmopts = parse_args(confvalue("ui.childopts", cppaths)) + [
         "-Dlogfile.name=ui.log",
         "-Dlogback.configurationFile=" + STORM_DIR + "/logback/cluster.xml",
@@ -293,7 +297,7 @@ def ui():
         "backtype.storm.ui.core", 
         jvmtype="-server", 
         jvmopts=jvmopts, 
-        extrajars=[STORM_DIR, STORM_DIR + "/conf"])
+        extrajars=[STORM_DIR, CLUSTER_CONF_DIR])
 
 def drpc():
     """Syntax: [storm drpc]
@@ -312,7 +316,7 @@ def drpc():
         "backtype.storm.daemon.drpc", 
         jvmtype="-server", 
         jvmopts=jvmopts, 
-        extrajars=[STORM_DIR + "/conf"])
+        extrajars=[CLUSTER_CONF_DIR])
 
 def dev_zookeeper():
     """Syntax: [storm dev-zookeeper]
@@ -321,11 +325,11 @@ def dev_zookeeper():
     "storm.zookeeper.port" as its port. This is only intended for development/testing, the
     Zookeeper instance launched is not configured to be used in production.
     """
-    cppaths = [STORM_DIR + "/conf"]
+    cppaths = [CLUSTER_CONF_DIR]
     exec_storm_class(
         "backtype.storm.command.dev_zookeeper", 
         jvmtype="-server", 
-        extrajars=[STORM_DIR + "/conf"])
+        extrajars=[CLUSTER_CONF_DIR])
 
 def version():
   """Syntax: [storm version]


### PR DESCRIPTION
When providing a hosted storm cluster with a dedicated gateway it is nice to have storm not require the user to setup ~/.storm/storm.yaml nor require them to provide a --config option.  This patch will have the storm script first look for ~/.storm/storm.yaml and if it is not present will fall back to CLUSTER_CONF_DIR + "/storm.yaml"
