### PR TITLE
UI: Adding UI settings to listen on specified interface

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -33,6 +33,7 @@ nimbus.topology.validator: "backtype.storm.nimbus.DefaultTopologyValidator"
 
 ### ui.* configs are for the master
 ui.port: 8080
+ui.host: 0.0.0.0
 ui.childopts: "-Xmx768m"
 
 drpc.port: 3772

--- a/src/clj/backtype/storm/ui/core.clj
+++ b/src/clj/backtype/storm/ui/core.clj
@@ -797,6 +797,7 @@
   (handler/site (-> main-routes catch-errors )))
 
 (defn start-server! [] (run-jetty app {:port (Integer. (*STORM-CONF* UI-PORT))
+                                       :host (*STORM-CONF* UI-HOST)
                                        :join? false}))
 
 (defn -main [] (start-server!))

--- a/src/jvm/backtype/storm/Config.java
+++ b/src/jvm/backtype/storm/Config.java
@@ -210,6 +210,11 @@ public class Config extends HashMap<String, Object> {
      * Storm UI binds to this port.
      */
     public static String UI_PORT = "ui.port";
+	
+	/**
+     * Storm UI binds to this interface.
+     */
+    public static String UI_HOST = "ui.host";
 
     /**
      * Childopts for Storm UI Java process.


### PR DESCRIPTION
Added possibility to change from default interface (0.0.0.0) to another by changing setting in storm.yaml (ui.host). 
Added default in defaults.yaml and populate changes to ui/core.clj .
Has no impact on existing code UI/topologies and may add some security to UI.
