### PR TITLE
Build java classfiles with debugging symbols

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -43,7 +43,7 @@
   :repositories {"sonatype"
                  "http://oss.sonatype.org/content/groups/public/"}
 
-  :javac-options {:debug true}
+  :javac-options ["-g"]
   :jvm-opts ["-Djava.library.path=/usr/local/lib:/opt/local/lib:/usr/lib"]
 
   :aot :all


### PR DESCRIPTION
project.clj includes the line `:javac-options {:debug true}`, however this does not have the desired effect. Changing it to `:javac-options ["-g"]` works.
