### PR TITLE
Issue 260 add worker classpath config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## Unreleased
+## 0.8.3
+
+ * Bug fix: Fix TransactionalMap and OpaqueMap to correctly do multiple updates to the same key in the same batch
+
+## 0.8.2
 
  * Added backtype.storm.scheduler.IsolationScheduler. This lets you run topologies that are completely isolated at the machine level. Configure Nimbus to isolate certain topologies, and how many machines to give to each of those topologies, with the isolation.scheduler.machines config in Nimbus's storm.yaml. Topologies run on the cluster that are not listed there will share whatever remaining machines there are on the cluster after machines are allocated to the listed topologies.
  * Storm UI now uses nimbus.host to find Nimbus rather than always using localhost (thanks Frostman)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.8.3
 
  * Bug fix: Fix TransactionalMap and OpaqueMap to correctly do multiple updates to the same key in the same batch
+ * Bug fix: Fix race condition between supervisor and Nimbus that could lead to stormconf.ser errors and infinite crashing of supervisor
 
 ## 0.8.2
 

--- a/bin/storm
+++ b/bin/storm
@@ -248,10 +248,11 @@ def nimbus(klass="backtype.storm.daemon.nimbus"):
         "-Dlogfile.name=nimbus.log",
         "-Dlog4j.configuration=storm.log.properties",
     ]
+    nimbus_classpath = confvalue("nimbus.classpath", cppaths)
     exec_storm_class(
-        klass, 
-        jvmtype="-server", 
-        extrajars=cppaths, 
+        klass,
+        jvmtype="-server",
+        extrajars=(cppaths+[nimbus_classpath]),
         jvmopts=jvmopts)
 
 def supervisor(klass="backtype.storm.daemon.supervisor"):

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -21,6 +21,7 @@ storm.local.mode.zmq: false
 nimbus.host: "localhost"
 nimbus.thrift.port: 6627
 nimbus.childopts: "-Xmx1024m"
+nimbus.classpath: ""
 nimbus.task.timeout.secs: 30
 nimbus.supervisor.timeout.secs: 60
 nimbus.monitor.freq.secs: 10
@@ -65,6 +66,7 @@ supervisor.enable: true
 
 ### worker.* configs are for task workers
 worker.childopts: "-Xmx768m"
+worker.classpath: ""
 worker.heartbeat.frequency.secs: 1
 
 task.heartbeat.frequency.secs: 3

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip18"
+(defproject storm "0.8.2-wip19"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip22"
+(defproject storm "0.8.2"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip20"
+(defproject storm "0.8.2-wip21"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip15"
+(defproject storm "0.8.2-wip16"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip19"
+(defproject storm "0.8.2-wip20"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip21"
+(defproject storm "0.8.2-wip22"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip17"
+(defproject storm "0.8.2-wip18"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2-wip16"
+(defproject storm "0.8.2-wip17"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   (do (println (str "ERROR: requires Leiningen 1.x but you are using " lein-version))
     (System/exit 1)))
 
-(defproject storm "0.8.2"
+(defproject storm "0.8.3-wip1"
   :source-path "src/clj"
   :test-path "test/clj"
   :java-source-path "src/jvm"

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -407,7 +407,8 @@
           stormroot (supervisor-stormdist-root conf storm-id)
           stormjar (supervisor-stormjar-path stormroot)
           storm-conf (read-supervisor-storm-conf conf storm-id)
-          classpath (add-to-classpath (current-classpath) [stormjar])
+          worker-classpath (conf WORKER-CLASSPATH)
+          classpath (add-to-classpath (current-classpath) [worker-classpath stormjar])
           childopts (.replaceAll (str (conf WORKER-CHILDOPTS) " " (storm-conf TOPOLOGY-WORKER-CHILDOPTS))
                                  "%ID%"
                                  (str port))

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -20,11 +20,17 @@
   (shutdown-all-workers [this])
   )
 
+(defn- assignments-snapshot [storm-cluster-state callback]
+  (let [storm-ids (.assignments storm-cluster-state callback)]
+     (->> (dofor [sid storm-ids] {sid (.assignment-info storm-cluster-state sid callback)})
+          (apply merge)
+          (filter-val not-nil?)
+          )))
 
-(defn- read-my-executors [storm-cluster-state storm-id assignment-id callback]
-  (let [assignment (.assignment-info storm-cluster-state storm-id callback)
+(defn- read-my-executors [assignments-snapshot storm-id assignment-id]
+  (let [assignment (get assignments-snapshot storm-id)
         my-executors (filter (fn [[_ [node _]]] (= node assignment-id))
-                               (:executor->node+port assignment))
+                           (:executor->node+port assignment))
         port-executors (apply merge-with
                           concat
                           (for [[executor [_ port]] my-executors]
@@ -34,29 +40,18 @@
                ;; need to cast to int b/c it might be a long (due to how yaml parses things)
                ;; doall is to avoid serialization/deserialization problems with lazy seqs
                [(Integer. port) (LocalAssignment. storm-id (doall executors))]
-               ))
-    ))
+               ))))
+
 
 (defn- read-assignments
   "Returns map from port to struct containing :storm-id and :executors"
-  [storm-cluster-state assignment-id callback]
-  (let [storm-ids (.assignments storm-cluster-state callback)]
-    (apply merge-with
-           (fn [& ignored]
-             (throw (RuntimeException.
-                     "Should not have multiple topologies assigned to one port")))
-           (dofor [sid storm-ids] (read-my-executors storm-cluster-state sid assignment-id callback))
-           )))
+  [assignments-snapshot assignment-id]
+  (->> (dofor [sid (keys assignments-snapshot)] (read-my-executors assignments-snapshot sid assignment-id))
+       (apply merge-with (fn [& ignored] (throw-runtime "Should not have multiple topologies assigned to one port")))))
 
 (defn- read-storm-code-locations
-  [storm-cluster-state callback]
-  (let [storm-ids (.assignments storm-cluster-state callback)]
-    (into {}
-      (dofor [sid storm-ids]
-        [sid (:master-code-dir (.assignment-info storm-cluster-state sid callback))]
-        ))
-    ))
-
+  [assignments-snapshot]
+  (map-val :master-code-dir assignments-snapshot))
 
 (defn- read-downloaded-storm-ids [conf]
   (map #(java.net.URLDecoder/decode %) (read-dir-contents (supervisor-stormdist-root conf)))
@@ -265,12 +260,12 @@
           ^ISupervisor isupervisor (:isupervisor supervisor)
           ^LocalState local-state (:local-state supervisor)
           sync-callback (fn [& ignored] (.add event-manager this))
-          storm-code-map (read-storm-code-locations storm-cluster-state sync-callback)
+          assignments-snapshot (assignments-snapshot storm-cluster-state sync-callback)
+          storm-code-map (read-storm-code-locations assignments-snapshot)
           downloaded-storm-ids (set (read-downloaded-storm-ids conf))
           all-assignment (read-assignments
-                           storm-cluster-state
-                           (:assignment-id supervisor)
-                           sync-callback)
+                           assignments-snapshot
+                           (:assignment-id supervisor))
           new-assignment (->> all-assignment
                               (filter-key #(.confirmAssigned isupervisor %)))
           assigned-storm-ids (assigned-storm-ids-from-port-assignments new-assignment)

--- a/src/jvm/backtype/storm/Config.java
+++ b/src/jvm/backtype/storm/Config.java
@@ -135,6 +135,13 @@ public class Config extends HashMap<String, Object> {
 
 
     /**
+     * This parameter is used to add additional classpath options for
+     * the nimbus daemon. This is useful for custom schedulers
+     */
+    public static String NIMBUS_CLASSPATH = "nimbus.classpath";
+
+
+    /**
      * How long without heartbeating a task can go before nimbus will consider the
      * task dead and reassign it to another location.
      */
@@ -305,6 +312,12 @@ public class Config extends HashMap<String, Object> {
      * with an identifier for this worker.
      */
     public static String WORKER_CHILDOPTS = "worker.childopts";
+
+
+    /**
+     * The additional classpath provided to workers launched by this supervisor.
+     */
+    public static String WORKER_CLASSPATH = "worker.classpath";
 
 
     /**

--- a/src/jvm/storm/trident/state/map/TransactionalMap.java
+++ b/src/jvm/storm/trident/state/map/TransactionalMap.java
@@ -9,21 +9,22 @@ import java.util.List;
 
 public class TransactionalMap<T> implements MapState<T> {
     public static <T> MapState<T> build(IBackingMap<TransactionalValue> backing) {
-        return new CachedBatchReadsMap<T>(new TransactionalMap<T>(backing));
+        return new TransactionalMap<T>(backing);
     }
-    
-    IBackingMap<TransactionalValue> _backing;
+
+    CachedBatchReadsMap<TransactionalValue> _backing;
     Long _currTx;
     
     protected TransactionalMap(IBackingMap<TransactionalValue> backing) {
-        _backing = backing;
+        _backing = new CachedBatchReadsMap(backing);
     }
     
     @Override
     public List<T> multiGet(List<List<Object>> keys) {
-        List<TransactionalValue> vals = _backing.multiGet(keys);
+        List<CachedBatchReadsMap.RetVal<TransactionalValue>> vals = _backing.multiGet(keys);
         List<T> ret = new ArrayList<T>(vals.size());
-        for(TransactionalValue v: vals) {
+        for(CachedBatchReadsMap.RetVal<TransactionalValue> retval: vals) {
+            TransactionalValue v = retval.val;
             if(v!=null) {
                 ret.add((T) v.getVal());
             } else {
@@ -35,26 +36,36 @@ public class TransactionalMap<T> implements MapState<T> {
 
     @Override
     public List<T> multiUpdate(List<List<Object>> keys, List<ValueUpdater> updaters) {
-        List<TransactionalValue> curr = _backing.multiGet(keys);
+        List<CachedBatchReadsMap.RetVal<TransactionalValue>> curr = _backing.multiGet(keys);
         List<TransactionalValue> newVals = new ArrayList<TransactionalValue>(curr.size());
+        List<List<Object>> newKeys = new ArrayList();
         List<T> ret = new ArrayList<T>();
         for(int i=0; i<curr.size(); i++) {
-            TransactionalValue<T> val = curr.get(i);
+            CachedBatchReadsMap.RetVal<TransactionalValue> retval = curr.get(i);
+            TransactionalValue<T> val = retval.val;
             ValueUpdater<T> updater = updaters.get(i);
             TransactionalValue<T> newVal;
+            boolean changed = false;
             if(val==null) {
                 newVal = new TransactionalValue<T>(_currTx, updater.update(null));
+                changed = true;
             } else {
-                if(_currTx!=null && _currTx.equals(val.getTxid())) {
+                if(_currTx!=null && _currTx.equals(val.getTxid()) && !retval.cached) {
                     newVal = val;
                 } else {
                     newVal = new TransactionalValue<T>(_currTx, updater.update(val.getVal()));
-                }    
+                    changed = true;
+                }
             }
             ret.add(newVal.getVal());
-            newVals.add(newVal);
+            if(changed) {
+                newVals.add(newVal);
+                newKeys.add(keys.get(i));
+            }
         }
-        _backing.multiPut(keys, newVals);
+        if(!newKeys.isEmpty()) {
+            _backing.multiPut(newKeys, newVals);
+        }
         return ret;
     }
 
@@ -70,10 +81,12 @@ public class TransactionalMap<T> implements MapState<T> {
     @Override
     public void beginCommit(Long txid) {
         _currTx = txid;
+        _backing.reset();
     }
 
     @Override
     public void commit(Long txid) {
         _currTx = null;
-    }  
+        _backing.reset();
+    }
 }

--- a/src/jvm/storm/trident/testing/MemoryBackingMap.java
+++ b/src/jvm/storm/trident/testing/MemoryBackingMap.java
@@ -1,0 +1,30 @@
+package storm.trident.testing;
+
+import storm.trident.state.map.IBackingMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MemoryBackingMap implements IBackingMap<Object> {
+    Map _vals = new HashMap();
+
+    @Override
+    public List<Object> multiGet(List<List<Object>> keys) {
+        List ret = new ArrayList();
+        for(List key: keys) {
+            ret.add(_vals.get(key));
+        }
+        return ret;
+    }
+
+    @Override
+    public void multiPut(List<List<Object>> keys, List<Object> vals) {
+        for(int i=0; i<keys.size(); i++) {
+            List key = keys.get(i);
+            Object val = vals.get(i);
+            _vals.put(key, val);
+        }
+    }
+}


### PR DESCRIPTION
This addresses Issue #260 with a slight addition of adding an option for adding to the nimbus classpath as well. This is useful for us as we have our own custom schedule which also has some HBase dependencies, so I found it pretty easy to add both at the same time.

I created this change off of the 0.8.3 branch because at the time, I couldn't get master to build via `lein`. The changes are small enough that the merge should apply cleanly regardless, but if you want me to rebase, let me know.
