### PR TITLE
Add `nimbus.classpath` and `worker.classpath` config options.

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -252,10 +252,11 @@ def nimbus(klass="backtype.storm.daemon.nimbus"):
         "-Dlogfile.name=nimbus.log",
         "-Dlogback.configurationFile=" + STORM_DIR + "/logback/cluster.xml",
     ]
+    nimbus_classpath = confvalue("nimbus.classpath", cppaths)
     exec_storm_class(
-        klass, 
-        jvmtype="-server", 
-        extrajars=cppaths, 
+        klass,
+        jvmtype="-server",
+        extrajars=(cppaths+[nimbus_classpath]),
         jvmopts=jvmopts)
 
 def supervisor(klass="backtype.storm.daemon.supervisor"):

--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -23,6 +23,7 @@ storm.thrift.transport: "backtype.storm.security.auth.SimpleTransportPlugin"
 nimbus.host: "localhost"
 nimbus.thrift.port: 6627
 nimbus.childopts: "-Xmx1024m"
+nimbus.classpath: ""
 nimbus.task.timeout.secs: 30
 nimbus.supervisor.timeout.secs: 60
 nimbus.monitor.freq.secs: 10
@@ -67,6 +68,7 @@ supervisor.enable: true
 
 ### worker.* configs are for task workers
 worker.childopts: "-Xmx768m"
+worker.classpath: ""
 worker.heartbeat.frequency.secs: 1
 
 task.heartbeat.frequency.secs: 3

--- a/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/src/clj/backtype/storm/daemon/supervisor.clj
@@ -408,7 +408,8 @@
           stormroot (supervisor-stormdist-root conf storm-id)
           stormjar (supervisor-stormjar-path stormroot)
           storm-conf (read-supervisor-storm-conf conf storm-id)
-          classpath (add-to-classpath (current-classpath) [stormjar])
+          worker-classpath (conf WORKER-CLASSPATH)
+          classpath (add-to-classpath (current-classpath) [worker-classpath stormjar])
           childopts (.replaceAll (str (conf WORKER-CHILDOPTS) " " (storm-conf TOPOLOGY-WORKER-CHILDOPTS))
                                  "%ID%"
                                  (str port))

--- a/src/jvm/backtype/storm/Config.java
+++ b/src/jvm/backtype/storm/Config.java
@@ -151,6 +151,13 @@ public class Config extends HashMap<String, Object> {
 
 
     /**
+     * This parameter is used to add additional classpath options for
+     * the nimbus daemon. This is useful for custom schedulers
+     */
+    public static String NIMBUS_CLASSPATH = "nimbus.classpath";
+
+
+    /**
      * How long without heartbeating a task can go before nimbus will consider the
      * task dead and reassign it to another location.
      */
@@ -325,6 +332,12 @@ public class Config extends HashMap<String, Object> {
      * with an identifier for this worker.
      */
     public static String WORKER_CHILDOPTS = "worker.childopts";
+
+
+    /**
+     * The additional classpath provided to workers launched by this supervisor.
+     */
+    public static String WORKER_CLASSPATH = "worker.classpath";
 
 
     /**


### PR DESCRIPTION
This addresses Issue #260 with a slight addition of adding an option for adding to the nimbus classpath as well. This is useful for us as we have our own custom schedule which also has some HBase dependencies, so I found it pretty easy to add both at the same time.

I technically created this change off of the 0.8.3 branch, because at the time, I couldn't get master to build via `lein`. The changes are small enough that the merge should apply cleanly regardless, but if you want me to rebase, let me know.
