### PR TITLE
0.9.0 cluster state inimbus

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject storm/storm "0.9.0-wip15"
+(defproject storm/storm "0.9.0-wip16"
   :url "http://storm-project.clj"
   :description "Distributed and fault-tolerant realtime computation"
   :license {:name "Eclipse Public License - Version 1.0" :url "https://github.com/nathanmarz/storm/blob/master/LICENSE.html"}

--- a/src/clj/backtype/storm/daemon/worker.clj
+++ b/src/clj/backtype/storm/daemon/worker.clj
@@ -134,12 +134,6 @@
   ;; actually just do it via interfaces. just need to make sure to hide setResource from tasks
   {})
 
-(defn mk-halting-timer []
-  (mk-timer :kill-fn (fn [t]
-                       (log-error t "Error when processing event")
-                       (halt-process! 20 "Error when processing an event")
-                       )))
-
 (defn worker-data [conf mq-context storm-id assignment-id port worker-id]
   (let [cluster-state (cluster/mk-distributed-cluster-state conf)
         storm-cluster-state (cluster/mk-storm-cluster-state cluster-state)

--- a/src/clj/backtype/storm/timer.clj
+++ b/src/clj/backtype/storm/timer.clj
@@ -79,3 +79,10 @@
 
 (defn timer-waiting? [timer]
   (Time/isThreadWaiting (:timer-thread timer)))
+
+(defn mk-halting-timer []
+  (mk-timer :kill-fn (fn [t]
+                       (log-error t "Error when processing event")
+                       (halt-process! 20 "Error when processing an event")
+                       )))
+

--- a/src/clj/backtype/storm/util.clj
+++ b/src/clj/backtype/storm/util.clj
@@ -823,3 +823,4 @@
                 (meta form))
               (list form x)))
   ([x form & more] `(-<> (-<> ~x ~form) ~@more)))
+

--- a/src/jvm/backtype/storm/metric/api/CountMetric.java
+++ b/src/jvm/backtype/storm/metric/api/CountMetric.java
@@ -2,7 +2,7 @@ package backtype.storm.metric.api;
 
 import backtype.storm.metric.api.IMetric;
 
-public class CountMetric implements IMetric, java.io.Serializable {
+public class CountMetric implements IMetric {
     long _value = 0;
 
     public CountMetric() {

--- a/src/jvm/backtype/storm/metric/api/MultiCountMetric.java
+++ b/src/jvm/backtype/storm/metric/api/MultiCountMetric.java
@@ -4,7 +4,7 @@ import backtype.storm.metric.api.IMetric;
 import java.util.HashMap;
 import java.util.Map;
 
-public class MultiCountMetric implements IMetric, java.io.Serializable {
+public class MultiCountMetric implements IMetric {
     Map<String, CountMetric> _value = new HashMap();
 
     public MultiCountMetric() {

--- a/src/jvm/backtype/storm/scheduler/INimbus.java
+++ b/src/jvm/backtype/storm/scheduler/INimbus.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 public interface INimbus {
-    void prepare(Map stormConf, String schedulerLocalDir);
+    void prepare(Map stormConf, String schedulerLocalDir, Object clusterState);
     /**
      * Returns all slots that are available for the next round of scheduling. A slot is available for scheduling
      * if it is free and can be assigned to, or if it is used and can be reassigned.

--- a/test/clj/backtype/storm/nimbus_test.clj
+++ b/test/clj/backtype/storm/nimbus_test.clj
@@ -183,8 +183,8 @@
 (defn isolation-nimbus []
   (let [standalone (nimbus/standalone-nimbus)]
     (reify INimbus
-      (prepare [this conf local-dir]
-        (.prepare standalone conf local-dir)
+      (prepare [this conf local-dir cluster-state]
+        (.prepare standalone conf local-dir cluster-state)
         )
       (allSlotsAvailableForScheduling [this supervisors topologies topologies-missing-assignments]
         (.allSlotsAvailableForScheduling standalone supervisors topologies topologies-missing-assignments))


### PR DESCRIPTION
This pull gives me access to cluster-state in INimbus, which is needed for this pull https://github.com/nathanmarz/storm-mesos/pull/5

"IMPORTANT: CuratorFramework instances are fully thread-safe. You should share one CuratorFramework per ZooKeeper cluster in your application." https://github.com/Netflix/curator/wiki/Framework

MesosNimbus needed zk style state, so this pull gets it done. Without making a 2nd curator framework.

I had to use Object for clusterState because ClusterState is a protocol, and therefore not accessible due to compilation ordering where javac goes first. If someone needs ClusterState in java in the future, we can rewrite it without protocols, but there's no sense changing all that code right now when only mesosnimbus needs it, and I wrote it partly in clojure. 
