### PR TITLE
pass cluster-state to INimbus

### DIFF
--- a/src/clj/backtype/storm/daemon/worker.clj
+++ b/src/clj/backtype/storm/daemon/worker.clj
@@ -134,12 +134,6 @@
   ;; actually just do it via interfaces. just need to make sure to hide setResource from tasks
   {})
 
-(defn mk-halting-timer []
-  (mk-timer :kill-fn (fn [t]
-                       (log-error t "Error when processing event")
-                       (halt-process! 20 "Error when processing an event")
-                       )))
-
 (defn worker-data [conf mq-context storm-id assignment-id port worker-id]
   (let [cluster-state (cluster/mk-distributed-cluster-state conf)
         storm-cluster-state (cluster/mk-storm-cluster-state cluster-state)

--- a/src/clj/backtype/storm/timer.clj
+++ b/src/clj/backtype/storm/timer.clj
@@ -79,3 +79,10 @@
 
 (defn timer-waiting? [timer]
   (Time/isThreadWaiting (:timer-thread timer)))
+
+(defn mk-halting-timer []
+  (mk-timer :kill-fn (fn [t]
+                       (log-error t "Error when processing event")
+                       (halt-process! 20 "Error when processing an event")
+                       )))
+

--- a/src/clj/backtype/storm/util.clj
+++ b/src/clj/backtype/storm/util.clj
@@ -823,3 +823,4 @@
                 (meta form))
               (list form x)))
   ([x form & more] `(-<> (-<> ~x ~form) ~@more)))
+

--- a/src/jvm/backtype/storm/scheduler/INimbus.java
+++ b/src/jvm/backtype/storm/scheduler/INimbus.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 public interface INimbus {
-    void prepare(Map stormConf, String schedulerLocalDir);
+    void prepare(Map stormConf, String schedulerLocalDir, Object clusterState);
     /**
      * Returns all slots that are available for the next round of scheduling. A slot is available for scheduling
      * if it is free and can be assigned to, or if it is used and can be reassigned.

--- a/test/clj/backtype/storm/nimbus_test.clj
+++ b/test/clj/backtype/storm/nimbus_test.clj
@@ -183,8 +183,8 @@
 (defn isolation-nimbus []
   (let [standalone (nimbus/standalone-nimbus)]
     (reify INimbus
-      (prepare [this conf local-dir]
-        (.prepare standalone conf local-dir)
+      (prepare [this conf local-dir cluster-state]
+        (.prepare standalone conf local-dir cluster-state)
         )
       (allSlotsAvailableForScheduling [this supervisors topologies topologies-missing-assignments]
         (.allSlotsAvailableForScheduling standalone supervisors topologies topologies-missing-assignments))


### PR DESCRIPTION
This pull gives me access to cluster-state in INimbus, which is needed for this pull https://github.com/nathanmarz/storm-mesos/issues/5

"IMPORTANT: CuratorFramework instances are fully thread-safe. You should share one CuratorFramework per ZooKeeper cluster in your application." https://github.com/Netflix/curator/wiki/Framework

MesosNimbus needed zk style state, so this pull gets it done. Without making a 2nd curator framework.

I had to use Object for clusterState because ClusterState is a protocol, and therefore not accessible due to compilation ordering where javac goes first in storm source code.  The clojure compiler does generate a class byte code for ClusterState but that comes after javac is finished. So other projects which depend on storm can merely cast the argument clusterState to ClusterState. 
