### PR TITLE
Millisecond-level tick generation granularity #2

### DIFF
--- a/storm-core/src/clj/backtype/storm/timer.clj
+++ b/storm-core/src/clj/backtype/storm/timer.clj
@@ -24,14 +24,22 @@
                       (fn []
                         (while @active
                           (try
-                            (let [[time-secs _ _ :as elem] (locking lock (.peek queue))]
-                              (if (and elem (>= (current-time-secs) time-secs))
+                            (let [[time-millis _ _ :as elem] (locking lock (.peek queue))]
+                              (if (and elem (>= (current-time-millis) time-millis))
                                 ;; imperative to not run the function inside the timer lock
                                 ;; otherwise, it's possible to deadlock if function deals with other locks
                                 ;; (like the submit lock)
                                 (let [afn (locking lock (second (.poll queue)))]
                                   (afn))
-                                (Time/sleep 1000)
+                                (if time-millis ;; if any events are scheduled
+                                  ;; sleep until event generation
+                                  ;; note that if any recurring events are scheduled then we will always go through
+                                  ;; this branch, sleeping only the exact necessary amount of time
+                                  (Time/sleep (- time-millis (current-time-millis)))
+                                  ;; else poll to see if any new event was scheduled
+                                  ;; this is in essence the response time for detecting any new event schedulings when
+                                  ;; there are no scheduled events
+                                  (Time/sleep 1000))
                                 ))
                             (catch Throwable t
                               ;; because the interrupted exception can be wrapped in a runtimeexception
@@ -59,7 +67,7 @@
   (let [id (uuid)
         ^PriorityQueue queue (:queue timer)]
     (locking (:lock timer)
-      (.add queue [(+ (current-time-secs) delay-secs) afn id])
+      (.add queue [(+ (current-time-millis) (long (* 1000 delay-secs))) afn id])
       )))
 
 (defn schedule-recurring [timer delay-secs recur-secs afn]

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -177,6 +177,9 @@
 (defn current-time-secs []
   (Time/currentTimeSecs))
 
+(defn current-time-millis []
+  (Time/currentTimeMillis))
+
 (defn clojurify-structure [s]
   (prewalk (fn [x]
               (cond (instance? Map x) (into {} x)


### PR DESCRIPTION
Issue #544.

This interprets the `topology.tick.tuple.freq.secs` configuration as a floating point number and converts it to milliseconds before scheduling.

The nimbus and supervisor scheduled events are unaffected.
