### PR TITLE
change default ackers number into the initial number of workers

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -82,7 +82,7 @@ topology.enable.message.timeouts: true
 topology.debug: false
 topology.optimize: true
 topology.workers: 1
-topology.acker.executors: 1
+topology.acker.executors: null
 topology.acker.tasks: null
 topology.tasks: null
 # maximum amount of time a message has to complete before it's considered failed

--- a/storm-core/src/clj/backtype/storm/daemon/common.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/common.clj
@@ -174,7 +174,7 @@
     (merge spout-inputs bolt-inputs)))
 
 (defn add-acker! [storm-conf ^StormTopology ret]
-  (let [num-executors (storm-conf TOPOLOGY-ACKER-EXECUTORS)
+  (let [num-executors (if (nil? (storm-conf TOPOLOGY-ACKER-EXECUTORS)) (storm-conf TOPOLOGY-WORKERS) (storm-conf TOPOLOGY-ACKER-EXECUTORS))
         acker-bolt (thrift/mk-bolt-spec* (acker-inputs ret)
                                          (new backtype.storm.daemon.acker)
                                          {ACKER-ACK-STREAM-ID (thrift/direct-output-fields ["id"])
@@ -289,7 +289,8 @@
     ))
 
 (defn has-ackers? [storm-conf]
-  (> (storm-conf TOPOLOGY-ACKER-EXECUTORS) 0))
+  (or (nil? (storm-conf TOPOLOGY-ACKER-EXECUTORS)) (> (storm-conf TOPOLOGY-ACKER-EXECUTORS) 0)))
+
 
 (defn num-start-executors [component]
   (thrift/parallelism-hint (.get_common component)))


### PR DESCRIPTION
#377

1 change default config of ackers.executors into null
2 in the code, check when it's null, use the initial number of workers
3. change has-ackers functions to reflect the new change
