### PR TITLE
Correcting typo in SystemBolt.java for collectionTimeP

### DIFF
--- a/storm-core/src/jvm/backtype/storm/metric/SystemBolt.java
+++ b/storm-core/src/jvm/backtype/storm/metric/SystemBolt.java
@@ -57,7 +57,7 @@ public class SystemBolt implements IBolt {
         @Override
         public Object getValueAndReset() {
             Long collectionCountP = _gcBean.getCollectionCount();
-            Long collectionTimeP = _gcBean.getCollectionCount();
+            Long collectionTimeP = _gcBean.getCollectionTime();
 
             Map ret = null;
             if(_collectionCount!=null && _collectionTime!=null) {


### PR DESCRIPTION
Correcting typo for collectionTimeP, to getCollectionTime instead of getCollectionCount
