### PR TITLE
Update project.clj - Bump snakeyaml dependency version from 1.9 to 1.11 (Latest Release)

### DIFF
--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -19,7 +19,7 @@
                  [org.clojure/tools.logging "0.2.3"]
                  [org.clojure/math.numeric-tower "0.0.1"]
                  [storm/carbonite "1.5.0"]
-                 [org.yaml/snakeyaml "1.9"]
+                 [org.yaml/snakeyaml "1.11"]
                  [org.apache.httpcomponents/httpclient "4.1.1"]
                  [storm/tools.cli "0.2.2"]
                  [com.googlecode.disruptor/disruptor "2.10.1"]


### PR DESCRIPTION
Storm is using a snakeyaml version that is now two revisions old. I have recently come across a dependency conflict when using Storm with JRuby 1.7.3. When running in ruby 1.9 mode JRuby utilizes the snakeyaml library, however the internal JRuby  version of snakeyaml 1.11. Since Storm is running an outdated version, it would make sense to propose the change in hopes of resolving this dependency conflict.
