### PR TITLE
Trim contents of VERSION in case of newline

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def VERSION (slurp "VERSION"))
+(def VERSION (.trim (slurp "VERSION")))
 (def MODULES (-> "MODULES" slurp (.split "\n")))
 (def DEPENDENCIES (for [m MODULES] [(symbol (str "storm/" m)) VERSION]))
 

--- a/storm-console-logging/project.clj
+++ b/storm-console-logging/project.clj
@@ -1,5 +1,5 @@
 (def ROOT-DIR (subs *file* 0 (- (count *file*) (count "project.clj"))))
-(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp))
+(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp (.trim)))
 
 (defproject storm/storm-console-logging VERSION
   :resource-paths ["logback"]

--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -1,5 +1,5 @@
 (def ROOT-DIR (subs *file* 0 (- (count *file*) (count "project.clj"))))
-(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp))
+(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp (.trim)))
 
 (defproject storm/storm-core VERSION
   :dependencies [[org.clojure/clojure "1.4.0"]

--- a/storm-lib/project.clj
+++ b/storm-lib/project.clj
@@ -1,5 +1,5 @@
 (def ROOT-DIR (subs *file* 0 (- (count *file*) (count "project.clj"))))
-(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp))
+(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp (.trim)))
 (def MODULES (-> ROOT-DIR (str "/../MODULES") slurp (.split "\n") (#(filter (fn [m] (not= m "storm-console-logging")) %)) ))
 (def DEPENDENCIES (for [m MODULES] [(symbol (str "storm/" m)) VERSION]))
 

--- a/storm-netty/project.clj
+++ b/storm-netty/project.clj
@@ -1,5 +1,5 @@
 (def ROOT-DIR (subs *file* 0 (- (count *file*) (count "project.clj"))))
-(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp))
+(def VERSION (-> ROOT-DIR (str "/../VERSION") slurp (.trim)))
 
 (eval `(defproject storm/storm-netty ~VERSION
   :dependencies [[storm/storm-core ~VERSION]


### PR DESCRIPTION
For consideration: It's easy to add a newline to the end of version and a pain to remember to leave off the newline, so we might trim the contents of `VERSION` instead.

Checked that `lein pom` creates a pom.xml with the correct version string when VERSION has a newline at the end of the file:
- /
- /storm-console-logging
- /storm-core
- /storm-lib
- /storm-netty
