### PR TITLE
Try at config validation

### DIFF
--- a/storm-core/src/dev/test-valid-non-collection-types.yaml
+++ b/storm-core/src/dev/test-valid-non-collection-types.yaml
@@ -1,0 +1,1 @@
+topology.workers: 3

--- a/storm-core/src/jvm/backtype/storm/nimbus/BasicTopologyValidator.java
+++ b/storm-core/src/jvm/backtype/storm/nimbus/BasicTopologyValidator.java
@@ -23,7 +23,7 @@ public class BasicTopologyValidator implements ITopologyValidator {
 
         while (it.hasNext()) {
             while (! toRet.isInstance(it.next())) {
-                toRet = toRet.getSuperClass();
+                toRet = toRet.getSuperclass();
             }
         }
         return toRet;
@@ -64,12 +64,14 @@ public class BasicTopologyValidator implements ITopologyValidator {
         return true;
     }
 
-    public void validateConfigurationTypes(Map<?, ?> conf) throws InvalidTopologyException {
+    protected void validateConfigurationTypes(Map<?, ?> conf) throws InvalidTopologyException {
         Map<?, ?> defaultConf = Utils.readDefaultConfig();
 
         for (Object key : conf.keySet()) {
-            if (defaultConf.containsKey(key) &&
-                    areObjectsInstances(defaultConf, conf, key)) {
+            if (! defaultConf.containsKey(key)) {
+                continue;
+            }
+            if (areObjectsInstances(defaultConf, conf, key)) {
                 continue;
             }
 

--- a/storm-core/src/jvm/backtype/storm/nimbus/BasicTopologyValidator.java
+++ b/storm-core/src/jvm/backtype/storm/nimbus/BasicTopologyValidator.java
@@ -1,0 +1,83 @@
+package backtype.storm.nimbus;
+
+import backtype.storm.generated.InvalidTopologyException;
+import backtype.storm.generated.StormTopology;
+import backtype.storm.utils.Utils;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+public class BasicTopologyValidator implements ITopologyValidator {
+    @Override
+    public void validate(String topologyName, Map topologyConf,
+            StormTopology topology) throws InvalidTopologyException {
+        validateConfigurationTypes(topologyConf);
+    }
+
+    protected Class getCommonAncestorClass(Iterable args) {
+        Iterator it = args.iterator();
+        if (! it.hasNext()) {
+            return Object.class;
+        }
+        Class toRet = it.next().getClass();
+
+        while (it.hasNext()) {
+            while (! toRet.isInstance(it.next())) {
+                toRet = toRet.getSuperClass();
+            }
+        }
+        return toRet;
+    }
+
+    protected boolean areObjectsInstances(Class cls, Iterable<?> vals) {
+        if (Object.class == cls) {
+            return true;
+        }
+        for (Object val : vals) {
+            if (cls.isInstance(val)) {
+                continue;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    protected boolean areObjectsInstances(Map<?, ?> defConf, Map<?, ?> conf, Object key) {
+        final Object defVal = defConf.get(key);
+        final Object confVal = conf.get(key);
+        Class defClass = defVal.getClass();
+
+        if (! defClass.isInstance(confVal)) {
+            return false;
+        }
+
+        if (defVal instanceof Map) {
+            return areObjectsInstances(getCommonAncestorClass(((Map)defVal).keySet()),
+                    ((Map) confVal).keySet());
+        }
+
+        if (defVal instanceof Iterable) {
+            return areObjectsInstances(getCommonAncestorClass((Iterable) defVal),
+                    (Iterable) confVal);
+        }
+
+        return true;
+    }
+
+    public void validateConfigurationTypes(Map<?, ?> conf) throws InvalidTopologyException {
+        Map<?, ?> defaultConf = Utils.readDefaultConfig();
+
+        for (Object key : conf.keySet()) {
+            if (defaultConf.containsKey(key) &&
+                    areObjectsInstances(defaultConf, conf, key)) {
+                continue;
+            }
+
+            // The type did not match.
+            String defaultClassName = defaultConf.getClass().getName();
+            String confClassName = conf.getClass().getName();
+            throw new InvalidTopologyException("Key '" + key + "' is expected to be a '"
+                    + defaultClassName + "' but was a '" + confClassName + "'.");
+        }
+    }
+}

--- a/storm-core/test/clj/backtype/storm/nimbus/BasicTopologyValidator_test.clj
+++ b/storm-core/test/clj/backtype/storm/nimbus/BasicTopologyValidator_test.clj
@@ -1,0 +1,17 @@
+(ns backtype.storm.nimbus.BasicTopologyValidator-test
+  (:use [backtype.storm config util])
+  (:use [clojure test])
+  (:import [backtype.storm.generated StormTopology])
+  (:import [backtype.storm.nimbus BasicTopologyValidator])
+  (:import [backtype.storm.utils Utils])
+  (:import [org.mockito Mockito])
+)
+
+(deftest test-valid-non-collection-types
+  (let [validator (BasicTopologyValidator.)
+        topo (Mockito/mock StormTopology)
+        conf (Utils/findAndReadConfigFile "test-valid-non-collection-types.yaml" true)
+        ]
+    (.validate validator "test-name" conf topo)
+  )
+)


### PR DESCRIPTION
For issue #581

This pull request is for input to see if this is a direction we could go.

In thinking about how to fix this sort of issue, I figure we want to validate the config at the point of topology submission, since after that it enters ZK state and would become a nuisance.

The idea is to use the defaults.yaml file we already have to validate types coming in with the topology.

Pros:
- Should only have to change the defaults.yaml to change the schema.
- Can be generalized to lists and maps

Cons:
- Need defaults for every config where the type truly matters.
  - Would have to change storm code to deal with null (e.g. use the empty String instead)
  - What if there are no sensible defaults?
- Lists with differing types prescribed by elements would not be enforced.

The code in this pull is incomplete, but I'm looking for comments on the direction.
