### PR TITLE
Add config schema validation

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -83,7 +83,6 @@ topology.debug: false
 topology.optimize: true
 topology.workers: 1
 topology.acker.executors: 1
-topology.acker.tasks: null
 topology.tasks: null
 # maximum amount of time a message has to complete before it's considered failed
 topology.message.timeout.secs: 30

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -134,6 +134,14 @@
     (catch Throwable t#
       (exception-cause? ~klass t#))))
 
+(defmacro thrown-cause-with-msg? [klass re & body]
+  `(try
+    ~@body
+    false
+    (catch Throwable t#
+      (and (re-matches ~re (.getMessage t#))
+        (exception-cause? ~klass t#)))))
+
 (defmacro forcat [[args aseq] & body]
   `(mapcat (fn [~args]
              ~@body)

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -720,47 +720,47 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_TRANSFER_BUFFER_SIZE="topology.transfer.buffer.size";
     public static final Object TOPOLOGY_TRANSFER_BUFFER_SIZE_SCHEMA = Number.class;
 
-    /**
-     * How often a tick tuple from the "__system" component and "__tick" stream should be sent
-     * to tasks. Meant to be used as a component-specific configuration.
-     */
-     public static final String TOPOLOGY_TICK_TUPLE_FREQ_SECS="topology.tick.tuple.freq.secs";
+   /**
+    * How often a tick tuple from the "__system" component and "__tick" stream should be sent
+    * to tasks. Meant to be used as a component-specific configuration.
+    */
+    public static final String TOPOLOGY_TICK_TUPLE_FREQ_SECS="topology.tick.tuple.freq.secs";
     public static final Object TOPOLOGY_TICK_TUPLE_FREQ_SECS_SCHEMA = Number.class;
 
 
-    /**
-     * Configure the wait strategy used for internal queuing. Can be used to tradeoff latency
-     * vs. throughput
-     */
-     public static final String TOPOLOGY_DISRUPTOR_WAIT_STRATEGY="topology.disruptor.wait.strategy";
+   /**
+    * Configure the wait strategy used for internal queuing. Can be used to tradeoff latency
+    * vs. throughput
+    */
+    public static final String TOPOLOGY_DISRUPTOR_WAIT_STRATEGY="topology.disruptor.wait.strategy";
     public static final Object TOPOLOGY_DISRUPTOR_WAIT_STRATEGY_SCHEMA = String.class;
     
-    /**
-     * The size of the shared thread pool for worker tasks to make use of. The thread pool can be accessed 
-     * via the TopologyContext.
-     */
-     public static final String TOPOLOGY_WORKER_SHARED_THREAD_POOL_SIZE="topology.worker.shared.thread.pool.size";
+   /**
+    * The size of the shared thread pool for worker tasks to make use of. The thread pool can be accessed 
+    * via the TopologyContext.
+    */
+    public static final String TOPOLOGY_WORKER_SHARED_THREAD_POOL_SIZE="topology.worker.shared.thread.pool.size";
     public static final Object TOPOLOGY_WORKER_SHARED_THREAD_POOL_SIZE_SCHEMA = Number.class;
 
-     /**
-      * The interval in seconds to use for determining whether to throttle error reported to Zookeeper. For example, 
-      * an interval of 10 seconds with topology.max.error.report.per.interval set to 5 will only allow 5 errors to be
-      * reported to Zookeeper per task for every 10 second interval of time.
-      */
-     public static final String TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS="topology.error.throttle.interval.secs";
+    /**
+     * The interval in seconds to use for determining whether to throttle error reported to Zookeeper. For example, 
+     * an interval of 10 seconds with topology.max.error.report.per.interval set to 5 will only allow 5 errors to be
+     * reported to Zookeeper per task for every 10 second interval of time.
+     */
+    public static final String TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS="topology.error.throttle.interval.secs";
     public static final Object TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS_SCHEMA = Number.class;
 
-     /**
-      * See doc for TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS
-      */
-     public static final String TOPOLOGY_MAX_ERROR_REPORT_PER_INTERVAL="topology.max.error.report.per.interval";
+    /**
+     * See doc for TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS
+     */
+    public static final String TOPOLOGY_MAX_ERROR_REPORT_PER_INTERVAL="topology.max.error.report.per.interval";
     public static final Object TOPOLOGY_MAX_ERROR_REPORT_PER_INTERVAL_SCHEMA = Number.class;
 
 
-     /**
-      * How often a batch can be emitted in a Trident topology.
-      */
-     public static final String TOPOLOGY_TRIDENT_BATCH_EMIT_INTERVAL_MILLIS="topology.trident.batch.emit.interval.millis";
+    /**
+     * How often a batch can be emitted in a Trident topology.
+     */
+    public static final String TOPOLOGY_TRIDENT_BATCH_EMIT_INTERVAL_MILLIS="topology.trident.batch.emit.interval.millis";
     public static final Object TOPOLOGY_TRIDENT_BATCH_EMIT_INTERVAL_MILLIS_SCHEMA = Number.class;
 
     /**

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -24,41 +24,119 @@ import java.util.Map;
  * Spouts. .</p>
  */
 public class Config extends HashMap<String, Object> {
+
+    /**
+     * Declares methods for validating non-simple Classes and providing feedback.
+     */
+    public static interface FieldValidator {
+        /**
+         * Returns the critera against which a field is validated in predicate form
+         */
+        public String getCriteriaPredicate();
+        /**
+         * Returns true if the field is valid, false otherwise.
+         */
+        public boolean validateField(Object field);
+    }
+
+    /**
+     * Returns a new FieldValidator for a List of the given Class.
+     * @param c the Class of elements composing the list
+     * @return the FieldValidator validating a list of elements of the given class
+     */
+    static FieldValidator FieldListValidatorFactory(final Class cls) {
+        return new FieldValidator() {
+            @Override
+            public String getCriteriaPredicate() {
+                return "must be a list of " + cls.getName() +"s";
+            }
+
+            @Override
+            public boolean validateField(Object field) {
+                if (field instanceof Iterable) {
+                    for (Object e : (Iterable)field) {
+                        if (! cls.isInstance(e)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Validates a list of Numbers
+     */
+    static Object NumbersValidator = FieldListValidatorFactory(Number.class);
+
+    /**
+     * Validates is a list of Strings
+     */
+    static Object StringsValidator = FieldListValidatorFactory(String.class);
+
+    /**
+     * Validates a power of 2
+     */
+    static Object PowerOf2Validator = new FieldValidator() {
+        @Override
+        public String getCriteriaPredicate() {
+            return "must be a power of 2";
+        }
+        @Override 
+        public boolean validateField(Object field) {
+            if (field instanceof Number) {
+                int i = ((Number) field).intValue();
+                if (i > 0 && (i & (i-1)) == 0) { // Test whether a power of 2
+                    return true;
+                }
+            }
+            return false;
+        }
+    };
     
     /**
      * The transporter for communication among Storm tasks
      */
     public static final String STORM_MESSAGING_TRANSPORT = "storm.messaging.transport";
+    public static final Object STORM_MESSAGING_TRANSPORT_SCHEMA = String.class;
     
     /**
      * Netty based messaging: The buffer size for send/recv buffer
      */
     public static String STORM_MESSAGING_NETTY_BUFFER_SIZE = "storm.messaging.netty.buffer_size"; 
+    public static final Object STORM_MESSAGING_NETTY_BUFFER_SIZE_SCHEMA = Number.class;
 
     /**
      * Netty based messaging: The max # of retries that a peer will perform when a remote is not accessible
      */
     public static String STORM_MESSAGING_NETTY_MAX_RETRIES = "storm.messaging.netty.max_retries"; 
+    public static final Object STORM_MESSAGING_NETTY_MAX_RETRIES_SCHEMA = Number.class;
 
     /**
      * Netty based messaging: The min # of milliseconds that a peer will wait. 
      */
     public static String STORM_MESSAGING_NETTY_MIN_SLEEP_MS = "storm.messaging.netty.min_wait_ms"; 
+    public static final Object STORM_MESSAGING_NETTY_MIN_SLEEP_MS_SCHEMA = Number.class;
 
     /**
      * Netty based messaging: The max # of milliseconds that a peer will wait. 
      */
     public static String STORM_MESSAGING_NETTY_MAX_SLEEP_MS = "storm.messaging.netty.max_wait_ms"; 
+    public static final Object STORM_MESSAGING_NETTY_MAX_SLEEP_MS_SCHEMA = Number.class;
 
     /**
      * A list of hosts of ZooKeeper servers used to manage the cluster.
      */
     public static final String STORM_ZOOKEEPER_SERVERS = "storm.zookeeper.servers";
+    public static final Object STORM_ZOOKEEPER_SERVERS_SCHEMA = StringsValidator;
 
     /**
      * The port Storm will use to connect to each of the ZooKeeper servers.
      */
     public static final String STORM_ZOOKEEPER_PORT = "storm.zookeeper.port";
+    public static final Object STORM_ZOOKEEPER_PORT_SCHEMA = Number.class;
 
     /**
      * A directory on the local filesystem used by Storm for any local
@@ -66,6 +144,7 @@ public class Config extends HashMap<String, Object> {
      * have permission to read/write from this location.
      */
     public static final String STORM_LOCAL_DIR = "storm.local.dir";
+    public static final Object STORM_LOCAL_DIR_SCHEMA = String.class;
 
     /**
      * A global task scheduler used to assign topologies's tasks to supervisors' wokers.
@@ -73,11 +152,13 @@ public class Config extends HashMap<String, Object> {
      * If this is not set, a default system scheduler will be used.
      */
     public static final String STORM_SCHEDULER = "storm.scheduler";
+    public static final Object STORM_SCHEDULER_SCHEMA = String.class;
 
     /**
      * The mode this Storm cluster is running in. Either "distributed" or "local".
      */
     public static final String STORM_CLUSTER_MODE = "storm.cluster.mode";
+    public static final Object STORM_CLUSTER_MODE_SCHEMA = String.class;
 
     /**
      * The hostname the supervisors/workers should report to nimbus. If unset, Storm will 
@@ -88,17 +169,20 @@ public class Config extends HashMap<String, Object> {
      * <code>InetAddress.getLocalHost().getCanonicalHostName()</code>.
      */
     public static final String STORM_LOCAL_HOSTNAME = "storm.local.hostname";
+    public static final Object STORM_LOCAL_HOSTNAME_SCHEMA = String.class;
 
     /**
      * The transport plug-in for Thrift client/server communication
      */
     public static final String STORM_THRIFT_TRANSPORT_PLUGIN = "storm.thrift.transport";
+    public static final Object STORM_THRIFT_TRANSPORT_PLUGIN_SCHEMA = String.class;
     
     /**
      * The serializer class for ListDelegate (tuple payload). 
      * The default serializer will be ListDelegateSerializer
      */
     public static final String TOPOLOGY_TUPLE_SERIALIZER = "topology.tuple.serializer";
+    public static final Object TOPOLOGY_TUPLE_SERIALIZER_SCHEMA = String.class;
 
     /**
      * Whether or not to use ZeroMQ for messaging in local mode. If this is set 
@@ -109,63 +193,75 @@ public class Config extends HashMap<String, Object> {
      * Defaults to false.
      */
     public static final String STORM_LOCAL_MODE_ZMQ = "storm.local.mode.zmq";
+    public static final Object STORM_LOCAL_MODE_ZMQ_SCHEMA = String.class;
 
     /**
      * The root location at which Storm stores data in ZooKeeper.
      */
     public static final String STORM_ZOOKEEPER_ROOT = "storm.zookeeper.root";
+    public static final Object STORM_ZOOKEEPER_ROOT_SCHEMA = String.class;
 
     /**
      * The session timeout for clients to ZooKeeper.
      */
     public static final String STORM_ZOOKEEPER_SESSION_TIMEOUT = "storm.zookeeper.session.timeout";
+    public static final Object STORM_ZOOKEEPER_SESSION_TIMEOUT_SCHEMA = Number.class;
 
     /**
      * The connection timeout for clients to ZooKeeper.
      */
     public static final String STORM_ZOOKEEPER_CONNECTION_TIMEOUT = "storm.zookeeper.connection.timeout";
+    public static final Object STORM_ZOOKEEPER_CONNECTION_TIMEOUT_SCHEMA = Number.class;
     
     
     /**
      * The number of times to retry a Zookeeper operation.
      */
     public static final String STORM_ZOOKEEPER_RETRY_TIMES="storm.zookeeper.retry.times";
+    public static final Object STORM_ZOOKEEPER_RETRY_TIMES_SCHEMA = Number.class;
     
     /**
      * The interval between retries of a Zookeeper operation.
      */
     public static final String STORM_ZOOKEEPER_RETRY_INTERVAL="storm.zookeeper.retry.interval";
+    public static final Object STORM_ZOOKEEPER_RETRY_INTERVAL_SCHEMA = Number.class;
 
     /**
      * The ceiling of the interval between retries of a Zookeeper operation.
      */
     public static final String STORM_ZOOKEEPER_RETRY_INTERVAL_CEILING="storm.zookeeper.retry.intervalceiling.millis";
+    public static final Object STORM_ZOOKEEPER_RETRY_INTERVAL_CEILING_SCHEMA = Number.class;
 
     /**
      * The Zookeeper authentication scheme to use, e.g. "digest". Defaults to no authentication.
      */
     public static final String STORM_ZOOKEEPER_AUTH_SCHEME="storm.zookeeper.auth.scheme";
+    public static final Object STORM_ZOOKEEPER_AUTH_SCHEME_SCHEMA = String.class;
     
     /**
      * A string representing the payload for Zookeeper authentication. It gets serialized using UTF-8 encoding during authentication.
      */
     public static final String STORM_ZOOKEEPER_AUTH_PAYLOAD="storm.zookeeper.auth.payload";
+    public static final Object STORM_ZOOKEEPER_AUTH_PAYLOAD_SCHEMA = String.class;
     
     /**
      * The id assigned to a running topology. The id is the storm name with a unique nonce appended.
      */
     public static final String STORM_ID = "storm.id";
+    public static final Object STORM_ID_SCHEMA = String.class;
     
     /**
      * The host that the master server is running on.
      */
     public static final String NIMBUS_HOST = "nimbus.host";
+    public static final Object NIMBUS_HOST_SCHEMA = String.class;
 
     /**
      * Which port the Thrift interface of Nimbus should run on. Clients should
      * connect to this port to upload jars and submit topologies.
      */
     public static final String NIMBUS_THRIFT_PORT = "nimbus.thrift.port";
+    public static final Object NIMBUS_THRIFT_PORT_SCHEMA = Number.class;
 
 
     /**
@@ -173,6 +269,7 @@ public class Config extends HashMap<String, Object> {
      * jvm options for the nimbus daemon.
      */
     public static final String NIMBUS_CHILDOPTS = "nimbus.childopts";
+    public static final Object NIMBUS_CHILDOPTS_SCHEMA = String.class;
 
 
     /**
@@ -180,6 +277,7 @@ public class Config extends HashMap<String, Object> {
      * task dead and reassign it to another location.
      */
     public static final String NIMBUS_TASK_TIMEOUT_SECS = "nimbus.task.timeout.secs";
+    public static final Object NIMBUS_TASK_TIMEOUT_SECS_SCHEMA = Number.class;
 
 
     /**
@@ -189,12 +287,14 @@ public class Config extends HashMap<String, Object> {
      * occuring.
      */
     public static final String NIMBUS_MONITOR_FREQ_SECS = "nimbus.monitor.freq.secs";
+    public static final Object NIMBUS_MONITOR_FREQ_SECS_SCHEMA = Number.class;
 
     /**
      * How often nimbus should wake the cleanup thread to clean the inbox.
      * @see NIMBUS_INBOX_JAR_EXPIRATION_SECS
      */
     public static final String NIMBUS_CLEANUP_INBOX_FREQ_SECS = "nimbus.cleanup.inbox.freq.secs";
+    public static final Object NIMBUS_CLEANUP_INBOX_FREQ_SECS_SCHEMA = Number.class;
 
     /**
      * The length of time a jar file lives in the inbox before being deleted by the cleanup thread.
@@ -206,12 +306,14 @@ public class Config extends HashMap<String, Object> {
      * @see NIMBUS_CLEANUP_FREQ_SECS
      */
     public static final String NIMBUS_INBOX_JAR_EXPIRATION_SECS = "nimbus.inbox.jar.expiration.secs";
+    public static final Object NIMBUS_INBOX_JAR_EXPIRATION_SECS_SCHEMA = Number.class;
 
     /**
      * How long before a supervisor can go without heartbeating before nimbus considers it dead
      * and stops assigning new work to it.
      */
     public static final String NIMBUS_SUPERVISOR_TIMEOUT_SECS = "nimbus.supervisor.timeout.secs";
+    public static final Object NIMBUS_SUPERVISOR_TIMEOUT_SECS_SCHEMA = Number.class;
 
     /**
      * A special timeout used when a task is initially launched. During launch, this is the timeout
@@ -221,18 +323,21 @@ public class Config extends HashMap<String, Object> {
      * to launching new JVM's and configuring them.</p>
      */
     public static final String NIMBUS_TASK_LAUNCH_SECS = "nimbus.task.launch.secs";
+    public static final Object NIMBUS_TASK_LAUNCH_SECS_SCHEMA = Number.class;
 
     /**
      * Whether or not nimbus should reassign tasks if it detects that a task goes down. 
      * Defaults to true, and it's not recommended to change this value.
      */
     public static final String NIMBUS_REASSIGN = "nimbus.reassign";
+    public static final Object NIMBUS_REASSIGN_SCHEMA = Boolean.class;
 
     /**
      * During upload/download with the master, how long an upload or download connection is idle
      * before nimbus considers it dead and drops the connection.
      */
     public static final String NIMBUS_FILE_COPY_EXPIRATION_SECS = "nimbus.file.copy.expiration.secs";
+    public static final Object NIMBUS_FILE_COPY_EXPIRATION_SECS_SCHEMA = Number.class;
 
     /**
      * A custom class that implements ITopologyValidator that is run whenever a
@@ -240,47 +345,56 @@ public class Config extends HashMap<String, Object> {
      * whether topologies are allowed to run or not.
      */
     public static final String NIMBUS_TOPOLOGY_VALIDATOR = "nimbus.topology.validator";
+    public static final Object NIMBUS_TOPOLOGY_VALIDATOR_SCHEMA = String.class;
 
     /**
      * Class name for authorization plugin for Nimbus
      */
     public static final String NIMBUS_AUTHORIZER = "nimbus.authorizer";
+    public static final Object NIMBUS_AUTHORIZER_SCHEMA = String.class;
     
     /**
      * Storm UI binds to this port.
      */
     public static final String UI_PORT = "ui.port";
+    public static final Object UI_PORT_SCHEMA = Number.class;
 
     /**
      * Childopts for Storm UI Java process.
      */
     public static final String UI_CHILDOPTS = "ui.childopts";
+    public static final Object UI_CHILDOPTS_SCHEMA = String.class;
     
     
     /**
      * List of DRPC servers so that the DRPCSpout knows who to talk to.
      */
     public static final String DRPC_SERVERS = "drpc.servers";
+    public static final Object DRPC_SERVERS_SCHEMA = StringsValidator;
 
     /**
      * This port is used by Storm DRPC for receiving DPRC requests from clients.
      */
     public static final String DRPC_PORT = "drpc.port";
+    public static final Object DRPC_PORT_SCHEMA = Number.class;
     
     /**
      * DRPC thrift server worker threads 
      */
     public static final String DRPC_WORKER_THREADS = "drpc.worker.threads";
+    public static final Object DRPC_WORKER_THREADS_SCHEMA = Number.class;
 
     /**
      * DRPC thrift server queue size 
      */
     public static final String DRPC_QUEUE_SIZE = "drpc.queue.size";
+    public static final Object DRPC_QUEUE_SIZE_SCHEMA = Number.class;
     
     /**
      * This port on Storm DRPC is used by DRPC topologies to receive function invocations and send results back. 
      */
     public static final String DRPC_INVOCATIONS_PORT = "drpc.invocations.port";  
+    public static final Object DRPC_INVOCATIONS_PORT_SCHEMA = Number.class;
     
     /**
      * The timeout on DRPC requests within the DRPC server. Defaults to 10 minutes. Note that requests can also
@@ -288,17 +402,20 @@ public class Config extends HashMap<String, Object> {
      * timeout for the topology implementing the DRPC function.
      */
     public static final String DRPC_REQUEST_TIMEOUT_SECS  = "drpc.request.timeout.secs";  
+    public static final Object DRPC_REQUEST_TIMEOUT_SECS_SCHEMA = Map.class;
     
     /**
      * the metadata configed on the supervisor
      */    
     public static final String SUPERVISOR_SCHEDULER_META = "supervisor.scheduler.meta";
+    public static final Object SUPERVISOR_SCHEDULER_META_SCHEMA = String.class;
     /**
      * A list of ports that can run workers on this supervisor. Each worker uses one port, and
      * the supervisor will only run one worker per port. Use this configuration to tune
      * how many workers run on each machine.
      */
     public static final String SUPERVISOR_SLOTS_PORTS = "supervisor.slots.ports";
+    public static final Object SUPERVISOR_SLOTS_PORTS_SCHEMA = NumbersValidator;
 
 
 
@@ -307,6 +424,7 @@ public class Config extends HashMap<String, Object> {
      * jvm options for the supervisor daemon.
      */
     public static final String SUPERVISOR_CHILDOPTS = "supervisor.childopts";
+    public static final Object SUPERVISOR_CHILDOPTS_SCHEMA = String.class;
 
 
     /**
@@ -314,6 +432,7 @@ public class Config extends HashMap<String, Object> {
      * restart the worker process.
      */
     public static final String SUPERVISOR_WORKER_TIMEOUT_SECS = "supervisor.worker.timeout.secs";
+    public static final Object SUPERVISOR_WORKER_TIMEOUT_SECS_SCHEMA = Number.class;
 
 
     /**
@@ -323,6 +442,7 @@ public class Config extends HashMap<String, Object> {
      * overhead to starting and configuring the JVM on launch.
      */
     public static final String SUPERVISOR_WORKER_START_TIMEOUT_SECS = "supervisor.worker.start.timeout.secs";
+    public static final Object SUPERVISOR_WORKER_START_TIMEOUT_SECS_SCHEMA = Number.class;
 
 
     /**
@@ -331,12 +451,14 @@ public class Config extends HashMap<String, Object> {
      * is used in the Storm unit tests.
      */
     public static final String SUPERVISOR_ENABLE = "supervisor.enable";
+    public static final Object SUPERVISOR_ENABLE_SCHEMA = Boolean.class;
 
 
     /**
      * how often the supervisor sends a heartbeat to the master.
      */
     public static final String SUPERVISOR_HEARTBEAT_FREQUENCY_SECS = "supervisor.heartbeat.frequency.secs";
+    public static final Object SUPERVISOR_HEARTBEAT_FREQUENCY_SECS_SCHEMA = Number.class;
 
 
     /**
@@ -344,23 +466,27 @@ public class Config extends HashMap<String, Object> {
      * need to be restarted.
      */
     public static final String SUPERVISOR_MONITOR_FREQUENCY_SECS = "supervisor.monitor.frequency.secs";
+    public static final Object SUPERVISOR_MONITOR_FREQUENCY_SECS_SCHEMA = Number.class;
     
     /**
      * The jvm opts provided to workers launched by this supervisor. All "%ID%" substrings are replaced
      * with an identifier for this worker.
      */
     public static final String WORKER_CHILDOPTS = "worker.childopts";
+    public static final Object WORKER_CHILDOPTS_SCHEMA = String.class;
 
 
     /**
      * How often this worker should heartbeat to the supervisor.
      */
     public static final String WORKER_HEARTBEAT_FREQUENCY_SECS = "worker.heartbeat.frequency.secs";
+    public static final Object WORKER_HEARTBEAT_FREQUENCY_SECS_SCHEMA = Number.class;
 
     /**
      * How often a task should heartbeat its status to the master.
      */
     public static final String TASK_HEARTBEAT_FREQUENCY_SECS = "task.heartbeat.frequency.secs";
+    public static final Object TASK_HEARTBEAT_FREQUENCY_SECS_SCHEMA = Number.class;
 
 
     /**
@@ -371,6 +497,7 @@ public class Config extends HashMap<String, Object> {
      * come through.
      */
     public static final String TASK_REFRESH_POLL_SECS = "task.refresh.poll.secs";
+    public static final Object TASK_REFRESH_POLL_SECS_SCHEMA = Number.class;
 
     
     
@@ -379,11 +506,13 @@ public class Config extends HashMap<String, Object> {
      * in unit tests to prevent tuples from being accidentally timed out during the test.
      */
     public static final String TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS = "topology.enable.message.timeouts";
+    public static final Object TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS_SCHEMA = Boolean.class;
     
     /**
      * When set to true, Storm will log every message that's emitted.
      */
     public static final String TOPOLOGY_DEBUG = "topology.debug";
+    public static final Object TOPOLOGY_DEBUG_SCHEMA = Boolean.class;
 
 
     /**
@@ -391,6 +520,7 @@ public class Config extends HashMap<String, Object> {
      * tasks in a single thread where appropriate.
      */
     public static final String TOPOLOGY_OPTIMIZE = "topology.optimize";
+    public static final Object TOPOLOGY_OPTIMIZE_SCHEMA = Boolean.class;
 
     /**
      * How many processes should be spawned around the cluster to execute this
@@ -399,6 +529,7 @@ public class Config extends HashMap<String, Object> {
      * on each component in the topology to tune the performance of a topology.
      */
     public static final String TOPOLOGY_WORKERS = "topology.workers";
+    public static final Object TOPOLOGY_WORKERS_SCHEMA = Number.class;
 
     /**
      * How many instances to create for a spout/bolt. A task runs on a thread with zero or more
@@ -409,6 +540,7 @@ public class Config extends HashMap<String, Object> {
      * guaranteeing that the same value goes to the same task).
      */
     public static final String TOPOLOGY_TASKS = "topology.tasks";
+    public static final Object TOPOLOGY_TASKS_SCHEMA = Number.class;
 
     /**
      * How many executors to spawn for ackers.
@@ -417,6 +549,7 @@ public class Config extends HashMap<String, Object> {
      * as they come off the spout, effectively disabling reliability.</p>
      */
     public static final String TOPOLOGY_ACKER_EXECUTORS = "topology.acker.executors";
+    public static final Object TOPOLOGY_ACKER_EXECUTORS_SCHEMA = Number.class;
 
 
     /**
@@ -426,6 +559,7 @@ public class Config extends HashMap<String, Object> {
      * the message at a later time.
      */
     public static final String TOPOLOGY_MESSAGE_TIMEOUT_SECS = "topology.message.timeout.secs";
+    public static final Object TOPOLOGY_MESSAGE_TIMEOUT_SECS_SCHEMA = Number.class;
 
     /**
      * A list of serialization registrations for Kryo ( http://code.google.com/p/kryo/ ),
@@ -436,6 +570,7 @@ public class Config extends HashMap<String, Object> {
      * See Kryo's documentation for more information about writing custom serializers.
      */
     public static final String TOPOLOGY_KRYO_REGISTER = "topology.kryo.register";
+    public static final Object TOPOLOGY_KRYO_REGISTER_SCHEMA = StringsValidator;
 
     /**
      * A list of classes that customize storm's kryo instance during start-up.
@@ -444,6 +579,7 @@ public class Config extends HashMap<String, Object> {
      * is called with storm's kryo instance as the only argument.
      */
     public static final String TOPOLOGY_KRYO_DECORATORS = "topology.kryo.decorators";
+    public static final Object TOPOLOGY_KRYO_DECORATORS_SCHEMA = StringsValidator;
 
     /**
      * Class that specifies how to create a Kryo instance for serialization. Storm will then apply
@@ -451,6 +587,7 @@ public class Config extends HashMap<String, Object> {
      * implements topology.fall.back.on.java.serialization and turns references off.
      */
     public static final String TOPOLOGY_KRYO_FACTORY = "topology.kryo.factory";
+    public static final Object TOPOLOGY_KRYO_FACTORY_SCHEMA = String.class;
 
     
     /**
@@ -464,6 +601,7 @@ public class Config extends HashMap<String, Object> {
      * rather than throw an error.
      */
     public static final String TOPOLOGY_SKIP_MISSING_KRYO_REGISTRATIONS= "topology.skip.missing.kryo.registrations";
+    public static final Object TOPOLOGY_SKIP_MISSING_KRYO_REGISTRATIONS_SCHEMA = Boolean.class;
 
     /*
      * A list of classes implementing IMetricsConsumer (See storm.yaml.example for exact config format).
@@ -471,6 +609,7 @@ public class Config extends HashMap<String, Object> {
      * Each listed class maps 1:1 to a system bolt named __metrics_ClassName#N, and it's parallelism is configurable.
      */
     public static final String TOPOLOGY_METRICS_CONSUMER_REGISTER = "topology.metrics.consumer.register";
+    public static final Object TOPOLOGY_METRICS_CONSUMER_REGISTER_SCHEMA = StringsValidator;
 
 
     /**
@@ -478,6 +617,7 @@ public class Config extends HashMap<String, Object> {
      * typically used in testing to limit the number of threads spawned in local mode.
      */
     public static final String TOPOLOGY_MAX_TASK_PARALLELISM="topology.max.task.parallelism";
+    public static final Object TOPOLOGY_MAX_TASK_PARALLELISM_SCHEMA = Number.class;
 
 
     /**
@@ -489,6 +629,7 @@ public class Config extends HashMap<String, Object> {
      * their tuples with a message id.
      */
     public static final String TOPOLOGY_MAX_SPOUT_PENDING="topology.max.spout.pending"; 
+    public static final Object TOPOLOGY_MAX_SPOUT_PENDING_SCHEMA = Number.class;
     
     /**
      * A class that implements a strategy for what to do when a spout needs to wait. Waiting is
@@ -498,37 +639,44 @@ public class Config extends HashMap<String, Object> {
      * 2. The spout has hit maxSpoutPending and can't emit any more tuples
      */
     public static final String TOPOLOGY_SPOUT_WAIT_STRATEGY="topology.spout.wait.strategy"; 
+    public static final Object TOPOLOGY_SPOUT_WAIT_STRATEGY_SCHEMA = String.class;
 
     /**
      * The amount of milliseconds the SleepEmptyEmitStrategy should sleep for.
      */
     public static final String TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS="topology.sleep.spout.wait.strategy.time.ms";     
+    public static final Object TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS_SCHEMA = Number.class;
     
     /**
      * The maximum amount of time a component gives a source of state to synchronize before it requests
      * synchronization again.
      */
     public static final String TOPOLOGY_STATE_SYNCHRONIZATION_TIMEOUT_SECS="topology.state.synchronization.timeout.secs";
+    public static final Object TOPOLOGY_STATE_SYNCHRONIZATION_TIMEOUT_SECS_SCHEMA = Number.class;
 
     /**
      * The percentage of tuples to sample to produce stats for a task.
      */
     public static final String TOPOLOGY_STATS_SAMPLE_RATE="topology.stats.sample.rate";
+    public static final Object TOPOLOGY_STATS_SAMPLE_RATE_SCHEMA = Number.class;
 
     /**
      * The time period that builtin metrics data in bucketed into. 
      */
     public static final String TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS="topology.builtin.metrics.bucket.size.secs";
+    public static final Object TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS_SCHEMA = Number.class;
 
     /**
      * Whether or not to use Java serialization in a topology.
      */
     public static final String TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION="topology.fall.back.on.java.serialization";
+    public static final Object TOPOLOGY_FALL_BACK_ON_JAVA_SERIALIZATION_SCHEMA = Boolean.class;
 
     /**
      * Topology-specific options for the worker child process. This is used in addition to WORKER_CHILDOPTS.
      */
     public static final String TOPOLOGY_WORKER_CHILDOPTS="topology.worker.childopts";
+    public static final Object TOPOLOGY_WORKER_CHILDOPTS_SCHEMA = String.class;
 
     /**
      * This config is available for TransactionalSpouts, and contains the id ( a String) for
@@ -536,6 +684,7 @@ public class Config extends HashMap<String, Object> {
      * topology in Zookeeper.
      */
     public static final String TOPOLOGY_TRANSACTIONAL_ID="topology.transactional.id";
+    public static final Object TOPOLOGY_TRANSACTIONAL_ID_SCHEMA = String.class;
     
     /**
      * A list of task hooks that are automatically added to every spout and bolt in the topology. An example
@@ -543,34 +692,40 @@ public class Config extends HashMap<String, Object> {
      * monitoring system. These hooks are instantiated using the zero-arg constructor.
      */
     public static final String TOPOLOGY_AUTO_TASK_HOOKS="topology.auto.task.hooks";
+    public static final Object TOPOLOGY_AUTO_TASK_HOOKS_SCHEMA = StringsValidator;
 
 
     /**
      * The size of the Disruptor receive queue for each executor. Must be a power of 2.
      */
     public static final String TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE="topology.executor.receive.buffer.size";
+    public static final Object TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE_SCHEMA = PowerOf2Validator;
 
     /**
      * The maximum number of messages to batch from the thread receiving off the network to the 
      * executor queues. Must be a power of 2.
      */
     public static final String TOPOLOGY_RECEIVER_BUFFER_SIZE="topology.receiver.buffer.size";
+    public static final Object TOPOLOGY_RECEIVER_BUFFER_SIZE_SCHEMA = PowerOf2Validator;
 
     /**
      * The size of the Disruptor send queue for each executor. Must be a power of 2.
      */
     public static final String TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE="topology.executor.send.buffer.size";
+    public static final Object TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE_SCHEMA = PowerOf2Validator;
 
     /**
      * The size of the Disruptor transfer queue for each worker.
      */
     public static final String TOPOLOGY_TRANSFER_BUFFER_SIZE="topology.transfer.buffer.size";
+    public static final Object TOPOLOGY_TRANSFER_BUFFER_SIZE_SCHEMA = Number.class;
 
     /**
      * How often a tick tuple from the "__system" component and "__tick" stream should be sent
      * to tasks. Meant to be used as a component-specific configuration.
      */
      public static final String TOPOLOGY_TICK_TUPLE_FREQ_SECS="topology.tick.tuple.freq.secs";
+    public static final Object TOPOLOGY_TICK_TUPLE_FREQ_SECS_SCHEMA = Number.class;
 
 
     /**
@@ -578,12 +733,14 @@ public class Config extends HashMap<String, Object> {
      * vs. throughput
      */
      public static final String TOPOLOGY_DISRUPTOR_WAIT_STRATEGY="topology.disruptor.wait.strategy";
+    public static final Object TOPOLOGY_DISRUPTOR_WAIT_STRATEGY_SCHEMA = String.class;
     
     /**
      * The size of the shared thread pool for worker tasks to make use of. The thread pool can be accessed 
      * via the TopologyContext.
      */
      public static final String TOPOLOGY_WORKER_SHARED_THREAD_POOL_SIZE="topology.worker.shared.thread.pool.size";
+    public static final Object TOPOLOGY_WORKER_SHARED_THREAD_POOL_SIZE_SCHEMA = Number.class;
 
      /**
       * The interval in seconds to use for determining whether to throttle error reported to Zookeeper. For example, 
@@ -591,44 +748,52 @@ public class Config extends HashMap<String, Object> {
       * reported to Zookeeper per task for every 10 second interval of time.
       */
      public static final String TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS="topology.error.throttle.interval.secs";
+    public static final Object TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS_SCHEMA = Number.class;
 
      /**
       * See doc for TOPOLOGY_ERROR_THROTTLE_INTERVAL_SECS
       */
      public static final String TOPOLOGY_MAX_ERROR_REPORT_PER_INTERVAL="topology.max.error.report.per.interval";
+    public static final Object TOPOLOGY_MAX_ERROR_REPORT_PER_INTERVAL_SCHEMA = Number.class;
 
 
      /**
       * How often a batch can be emitted in a Trident topology.
       */
      public static final String TOPOLOGY_TRIDENT_BATCH_EMIT_INTERVAL_MILLIS="topology.trident.batch.emit.interval.millis";
+    public static final Object TOPOLOGY_TRIDENT_BATCH_EMIT_INTERVAL_MILLIS_SCHEMA = Number.class;
 
     /**
      * Name of the topology. This config is automatically set by Storm when the topology is submitted.
      */
     public static final String TOPOLOGY_NAME="topology.name";  
+    public static final Object TOPOLOGY_NAME_SCHEMA = String.class;
     
     /**
      * The root directory in ZooKeeper for metadata about TransactionalSpouts.
      */
     public static final String TRANSACTIONAL_ZOOKEEPER_ROOT="transactional.zookeeper.root";
+    public static final Object TRANSACTIONAL_ZOOKEEPER_ROOT_SCHEMA = String.class;
     
     /**
      * The list of zookeeper servers in which to keep the transactional state. If null (which is default),
      * will use storm.zookeeper.servers
      */
     public static final String TRANSACTIONAL_ZOOKEEPER_SERVERS="transactional.zookeeper.servers";
+    public static final Object TRANSACTIONAL_ZOOKEEPER_SERVERS_SCHEMA = StringsValidator;
 
     /**
      * The port to use to connect to the transactional zookeeper servers. If null (which is default),
      * will use storm.zookeeper.port
      */
     public static final String TRANSACTIONAL_ZOOKEEPER_PORT="transactional.zookeeper.port";
+    public static final Object TRANSACTIONAL_ZOOKEEPER_PORT_SCHEMA = Number.class;
     
     /**
      * The number of threads that should be used by the zeromq context in each worker process.
      */
     public static final String ZMQ_THREADS = "zmq.threads";
+    public static final Object ZMQ_THREADS_SCHEMA = Number.class;
 
     /**
      * How long a connection should retry sending messages to a target host when
@@ -636,12 +801,14 @@ public class Config extends HashMap<String, Object> {
      * certainly be ignored.
      */
     public static final String ZMQ_LINGER_MILLIS = "zmq.linger.millis";
+    public static final Object ZMQ_LINGER_MILLIS_SCHEMA = Number.class;
 
     /**
      * The high water for the ZeroMQ push sockets used for networking. Use this config to prevent buffer explosion
      * on the networking layer.
      */
     public static final String ZMQ_HWM = "zmq.hwm";
+    public static final Object ZMQ_HWM_SCHEMA = Number.class;
         
     /**
      * This value is passed to spawned JVMs (e.g., Nimbus, Supervisor, and Workers)
@@ -650,6 +817,7 @@ public class Config extends HashMap<String, Object> {
      * Storm uses the ZeroMQ and JZMQ native libs. 
      */
     public static final String JAVA_LIBRARY_PATH = "java.library.path";
+    public static final Object JAVA_LIBRARY_PATH_SCHEMA = String.class;
     
     /**
      * The path to use as the zookeeper dir when running a zookeeper server via
@@ -657,13 +825,15 @@ public class Config extends HashMap<String, Object> {
      * it is not a production grade zookeeper setup.
      */
     public static final String DEV_ZOOKEEPER_PATH = "dev.zookeeper.path";
+    public static final Object DEV_ZOOKEEPER_PATH_SCHEMA = String.class;
     
     /**
      * A map from topology name to the number of machines that should be dedicated for that topology. Set storm.scheduler
      * to backtype.storm.scheduler.IsolationScheduler to make use of the isolation scheduler.
      */
     public static final String ISOLATION_SCHEDULER_MACHINES = "isolation.scheduler.machines";
-        
+    public static final Object ISOLATION_SCHEDULER_MACHINES_SCHEMA = Number.class;
+
     public static void setDebug(Map conf, boolean isOn) {
         conf.put(Config.TOPOLOGY_DEBUG, isOn);
     } 

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -193,7 +193,7 @@ public class Config extends HashMap<String, Object> {
      * Defaults to false.
      */
     public static final String STORM_LOCAL_MODE_ZMQ = "storm.local.mode.zmq";
-    public static final Object STORM_LOCAL_MODE_ZMQ_SCHEMA = String.class;
+    public static final Object STORM_LOCAL_MODE_ZMQ_SCHEMA = Boolean.class;
 
     /**
      * The root location at which Storm stores data in ZooKeeper.
@@ -402,13 +402,13 @@ public class Config extends HashMap<String, Object> {
      * timeout for the topology implementing the DRPC function.
      */
     public static final String DRPC_REQUEST_TIMEOUT_SECS  = "drpc.request.timeout.secs";  
-    public static final Object DRPC_REQUEST_TIMEOUT_SECS_SCHEMA = Map.class;
+    public static final Object DRPC_REQUEST_TIMEOUT_SECS_SCHEMA = Number.class;
     
     /**
      * the metadata configed on the supervisor
      */    
     public static final String SUPERVISOR_SCHEDULER_META = "supervisor.scheduler.meta";
-    public static final Object SUPERVISOR_SCHEDULER_META_SCHEMA = String.class;
+    public static final Object SUPERVISOR_SCHEDULER_META_SCHEMA = Map.class;
     /**
      * A list of ports that can run workers on this supervisor. Each worker uses one port, and
      * the supervisor will only run one worker per port. Use this configuration to tune

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -1,5 +1,6 @@
 package backtype.storm;
 
+import backtype.storm.ConfigValidation;
 import backtype.storm.serialization.IKryoDecorator;
 import backtype.storm.serialization.IKryoFactory;
 import com.esotericsoftware.kryo.Serializer;
@@ -14,94 +15,23 @@ import java.util.Map;
  * all the configs that can be set. It also makes it easier to do things like add 
  * serializations.
  * 
- * <p>This class also provides constants for all the configurations possible on a Storm
- * cluster and Storm topology. Default values for these configs can be found in
- * defaults.yaml.</p>
+ * <p>This class also provides constants for all the configurations possible on
+ * a Storm cluster and Storm topology. Each constant is paired with a schema
+ * that defines the validity criterion of the corresponding field. Default
+ * values for these configs can be found in defaults.yaml.</p>
  *
  * <p>Note that you may put other configurations in any of the configs. Storm
  * will ignore anything it doesn't recognize, but your topologies are free to make
  * use of them by reading them in the prepare method of Bolts or the open method of 
- * Spouts. .</p>
+ * Spouts.</p>
  */
 public class Config extends HashMap<String, Object> {
-
-    /**
-     * Declares methods for validating non-simple Classes and providing feedback.
-     */
-    public static interface FieldValidator {
-        /**
-         * Returns the critera against which a field is validated in predicate form
-         */
-        public String getCriteriaPredicate();
-        /**
-         * Returns true if the field is valid, false otherwise.
-         */
-        public boolean validateField(Object field);
-    }
-
-    /**
-     * Returns a new FieldValidator for a List of the given Class.
-     * @param c the Class of elements composing the list
-     * @return the FieldValidator validating a list of elements of the given class
-     */
-    static FieldValidator FieldListValidatorFactory(final Class cls) {
-        return new FieldValidator() {
-            @Override
-            public String getCriteriaPredicate() {
-                return "must be a list of " + cls.getName() +"s";
-            }
-
-            @Override
-            public boolean validateField(Object field) {
-                if (field instanceof Iterable) {
-                    for (Object e : (Iterable)field) {
-                        if (! cls.isInstance(e)) {
-                            return false;
-                        }
-                    }
-                    return true;
-                }
-                return false;
-            }
-        };
-    }
-
-    /**
-     * Validates a list of Numbers
-     */
-    static Object NumbersValidator = FieldListValidatorFactory(Number.class);
-
-    /**
-     * Validates is a list of Strings
-     */
-    static Object StringsValidator = FieldListValidatorFactory(String.class);
-
-    /**
-     * Validates a power of 2
-     */
-    static Object PowerOf2Validator = new FieldValidator() {
-        @Override
-        public String getCriteriaPredicate() {
-            return "must be a power of 2";
-        }
-        @Override 
-        public boolean validateField(Object field) {
-            if (field instanceof Number) {
-                int i = ((Number) field).intValue();
-                if (i > 0 && (i & (i-1)) == 0) { // Test whether a power of 2
-                    return true;
-                }
-            }
-            return false;
-        }
-    };
-    
     /**
      * The transporter for communication among Storm tasks
      */
     public static final String STORM_MESSAGING_TRANSPORT = "storm.messaging.transport";
     public static final Object STORM_MESSAGING_TRANSPORT_SCHEMA = String.class;
-    
+
     /**
      * Netty based messaging: The buffer size for send/recv buffer
      */
@@ -130,7 +60,7 @@ public class Config extends HashMap<String, Object> {
      * A list of hosts of ZooKeeper servers used to manage the cluster.
      */
     public static final String STORM_ZOOKEEPER_SERVERS = "storm.zookeeper.servers";
-    public static final Object STORM_ZOOKEEPER_SERVERS_SCHEMA = StringsValidator;
+    public static final Object STORM_ZOOKEEPER_SERVERS_SCHEMA = ConfigValidation.StringsValidator;
 
     /**
      * The port Storm will use to connect to each of the ZooKeeper servers.
@@ -176,7 +106,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String STORM_THRIFT_TRANSPORT_PLUGIN = "storm.thrift.transport";
     public static final Object STORM_THRIFT_TRANSPORT_PLUGIN_SCHEMA = String.class;
-    
+
     /**
      * The serializer class for ListDelegate (tuple payload). 
      * The default serializer will be ListDelegateSerializer
@@ -212,14 +142,13 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String STORM_ZOOKEEPER_CONNECTION_TIMEOUT = "storm.zookeeper.connection.timeout";
     public static final Object STORM_ZOOKEEPER_CONNECTION_TIMEOUT_SCHEMA = Number.class;
-    
-    
+
     /**
      * The number of times to retry a Zookeeper operation.
      */
     public static final String STORM_ZOOKEEPER_RETRY_TIMES="storm.zookeeper.retry.times";
     public static final Object STORM_ZOOKEEPER_RETRY_TIMES_SCHEMA = Number.class;
-    
+
     /**
      * The interval between retries of a Zookeeper operation.
      */
@@ -237,19 +166,19 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String STORM_ZOOKEEPER_AUTH_SCHEME="storm.zookeeper.auth.scheme";
     public static final Object STORM_ZOOKEEPER_AUTH_SCHEME_SCHEMA = String.class;
-    
+
     /**
      * A string representing the payload for Zookeeper authentication. It gets serialized using UTF-8 encoding during authentication.
      */
     public static final String STORM_ZOOKEEPER_AUTH_PAYLOAD="storm.zookeeper.auth.payload";
     public static final Object STORM_ZOOKEEPER_AUTH_PAYLOAD_SCHEMA = String.class;
-    
+
     /**
      * The id assigned to a running topology. The id is the storm name with a unique nonce appended.
      */
     public static final String STORM_ID = "storm.id";
     public static final Object STORM_ID_SCHEMA = String.class;
-    
+
     /**
      * The host that the master server is running on.
      */
@@ -352,7 +281,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String NIMBUS_AUTHORIZER = "nimbus.authorizer";
     public static final Object NIMBUS_AUTHORIZER_SCHEMA = String.class;
-    
+
     /**
      * Storm UI binds to this port.
      */
@@ -364,20 +293,19 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String UI_CHILDOPTS = "ui.childopts";
     public static final Object UI_CHILDOPTS_SCHEMA = String.class;
-    
-    
+
     /**
      * List of DRPC servers so that the DRPCSpout knows who to talk to.
      */
     public static final String DRPC_SERVERS = "drpc.servers";
-    public static final Object DRPC_SERVERS_SCHEMA = StringsValidator;
+    public static final Object DRPC_SERVERS_SCHEMA = ConfigValidation.StringsValidator;
 
     /**
      * This port is used by Storm DRPC for receiving DPRC requests from clients.
      */
     public static final String DRPC_PORT = "drpc.port";
     public static final Object DRPC_PORT_SCHEMA = Number.class;
-    
+
     /**
      * DRPC thrift server worker threads 
      */
@@ -389,24 +317,24 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String DRPC_QUEUE_SIZE = "drpc.queue.size";
     public static final Object DRPC_QUEUE_SIZE_SCHEMA = Number.class;
-    
+
     /**
      * This port on Storm DRPC is used by DRPC topologies to receive function invocations and send results back. 
      */
-    public static final String DRPC_INVOCATIONS_PORT = "drpc.invocations.port";  
+    public static final String DRPC_INVOCATIONS_PORT = "drpc.invocations.port";
     public static final Object DRPC_INVOCATIONS_PORT_SCHEMA = Number.class;
-    
+
     /**
      * The timeout on DRPC requests within the DRPC server. Defaults to 10 minutes. Note that requests can also
      * timeout based on the socket timeout on the DRPC client, and separately based on the topology message
      * timeout for the topology implementing the DRPC function.
      */
-    public static final String DRPC_REQUEST_TIMEOUT_SECS  = "drpc.request.timeout.secs";  
+    public static final String DRPC_REQUEST_TIMEOUT_SECS  = "drpc.request.timeout.secs";
     public static final Object DRPC_REQUEST_TIMEOUT_SECS_SCHEMA = Number.class;
-    
+
     /**
      * the metadata configed on the supervisor
-     */    
+     */
     public static final String SUPERVISOR_SCHEDULER_META = "supervisor.scheduler.meta";
     public static final Object SUPERVISOR_SCHEDULER_META_SCHEMA = Map.class;
     /**
@@ -415,7 +343,7 @@ public class Config extends HashMap<String, Object> {
      * how many workers run on each machine.
      */
     public static final String SUPERVISOR_SLOTS_PORTS = "supervisor.slots.ports";
-    public static final Object SUPERVISOR_SLOTS_PORTS_SCHEMA = NumbersValidator;
+    public static final Object SUPERVISOR_SLOTS_PORTS_SCHEMA = ConfigValidation.NumbersValidator;
 
 
 
@@ -467,7 +395,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String SUPERVISOR_MONITOR_FREQUENCY_SECS = "supervisor.monitor.frequency.secs";
     public static final Object SUPERVISOR_MONITOR_FREQUENCY_SECS_SCHEMA = Number.class;
-    
+
     /**
      * The jvm opts provided to workers launched by this supervisor. All "%ID%" substrings are replaced
      * with an identifier for this worker.
@@ -499,15 +427,15 @@ public class Config extends HashMap<String, Object> {
     public static final String TASK_REFRESH_POLL_SECS = "task.refresh.poll.secs";
     public static final Object TASK_REFRESH_POLL_SECS_SCHEMA = Number.class;
 
-    
-    
+
+
     /**
      * True if Storm should timeout messages or not. Defaults to true. This is meant to be used
      * in unit tests to prevent tuples from being accidentally timed out during the test.
      */
     public static final String TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS = "topology.enable.message.timeouts";
     public static final Object TOPOLOGY_ENABLE_MESSAGE_TIMEOUTS_SCHEMA = Boolean.class;
-    
+
     /**
      * When set to true, Storm will log every message that's emitted.
      */
@@ -570,7 +498,7 @@ public class Config extends HashMap<String, Object> {
      * See Kryo's documentation for more information about writing custom serializers.
      */
     public static final String TOPOLOGY_KRYO_REGISTER = "topology.kryo.register";
-    public static final Object TOPOLOGY_KRYO_REGISTER_SCHEMA = StringsValidator;
+    public static final Object TOPOLOGY_KRYO_REGISTER_SCHEMA = ConfigValidation.StringsValidator;
 
     /**
      * A list of classes that customize storm's kryo instance during start-up.
@@ -579,7 +507,7 @@ public class Config extends HashMap<String, Object> {
      * is called with storm's kryo instance as the only argument.
      */
     public static final String TOPOLOGY_KRYO_DECORATORS = "topology.kryo.decorators";
-    public static final Object TOPOLOGY_KRYO_DECORATORS_SCHEMA = StringsValidator;
+    public static final Object TOPOLOGY_KRYO_DECORATORS_SCHEMA = ConfigValidation.StringsValidator;
 
     /**
      * Class that specifies how to create a Kryo instance for serialization. Storm will then apply
@@ -589,7 +517,7 @@ public class Config extends HashMap<String, Object> {
     public static final String TOPOLOGY_KRYO_FACTORY = "topology.kryo.factory";
     public static final Object TOPOLOGY_KRYO_FACTORY_SCHEMA = String.class;
 
-    
+
     /**
      * Whether or not Storm should skip the loading of kryo registrations for which it
      * does not know the class or have the serializer implementation. Otherwise, the task will
@@ -609,7 +537,7 @@ public class Config extends HashMap<String, Object> {
      * Each listed class maps 1:1 to a system bolt named __metrics_ClassName#N, and it's parallelism is configurable.
      */
     public static final String TOPOLOGY_METRICS_CONSUMER_REGISTER = "topology.metrics.consumer.register";
-    public static final Object TOPOLOGY_METRICS_CONSUMER_REGISTER_SCHEMA = StringsValidator;
+    public static final Object TOPOLOGY_METRICS_CONSUMER_REGISTER_SCHEMA = ConfigValidation.StringsValidator;
 
 
     /**
@@ -630,7 +558,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String TOPOLOGY_MAX_SPOUT_PENDING="topology.max.spout.pending"; 
     public static final Object TOPOLOGY_MAX_SPOUT_PENDING_SCHEMA = Number.class;
-    
+
     /**
      * A class that implements a strategy for what to do when a spout needs to wait. Waiting is
      * triggered in one of two conditions:
@@ -644,9 +572,9 @@ public class Config extends HashMap<String, Object> {
     /**
      * The amount of milliseconds the SleepEmptyEmitStrategy should sleep for.
      */
-    public static final String TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS="topology.sleep.spout.wait.strategy.time.ms";     
+    public static final String TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS="topology.sleep.spout.wait.strategy.time.ms";
     public static final Object TOPOLOGY_SLEEP_SPOUT_WAIT_STRATEGY_TIME_MS_SCHEMA = Number.class;
-    
+
     /**
      * The maximum amount of time a component gives a source of state to synchronize before it requests
      * synchronization again.
@@ -685,34 +613,34 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String TOPOLOGY_TRANSACTIONAL_ID="topology.transactional.id";
     public static final Object TOPOLOGY_TRANSACTIONAL_ID_SCHEMA = String.class;
-    
+
     /**
      * A list of task hooks that are automatically added to every spout and bolt in the topology. An example
      * of when you'd do this is to add a hook that integrates with your internal 
      * monitoring system. These hooks are instantiated using the zero-arg constructor.
      */
     public static final String TOPOLOGY_AUTO_TASK_HOOKS="topology.auto.task.hooks";
-    public static final Object TOPOLOGY_AUTO_TASK_HOOKS_SCHEMA = StringsValidator;
+    public static final Object TOPOLOGY_AUTO_TASK_HOOKS_SCHEMA = ConfigValidation.StringsValidator;
 
 
     /**
      * The size of the Disruptor receive queue for each executor. Must be a power of 2.
      */
     public static final String TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE="topology.executor.receive.buffer.size";
-    public static final Object TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE_SCHEMA = PowerOf2Validator;
+    public static final Object TOPOLOGY_EXECUTOR_RECEIVE_BUFFER_SIZE_SCHEMA = ConfigValidation.PowerOf2Validator;
 
     /**
      * The maximum number of messages to batch from the thread receiving off the network to the 
      * executor queues. Must be a power of 2.
      */
     public static final String TOPOLOGY_RECEIVER_BUFFER_SIZE="topology.receiver.buffer.size";
-    public static final Object TOPOLOGY_RECEIVER_BUFFER_SIZE_SCHEMA = PowerOf2Validator;
+    public static final Object TOPOLOGY_RECEIVER_BUFFER_SIZE_SCHEMA = ConfigValidation.PowerOf2Validator;
 
     /**
      * The size of the Disruptor send queue for each executor. Must be a power of 2.
      */
     public static final String TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE="topology.executor.send.buffer.size";
-    public static final Object TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE_SCHEMA = PowerOf2Validator;
+    public static final Object TOPOLOGY_EXECUTOR_SEND_BUFFER_SIZE_SCHEMA = ConfigValidation.PowerOf2Validator;
 
     /**
      * The size of the Disruptor transfer queue for each worker.
@@ -734,7 +662,7 @@ public class Config extends HashMap<String, Object> {
     */
     public static final String TOPOLOGY_DISRUPTOR_WAIT_STRATEGY="topology.disruptor.wait.strategy";
     public static final Object TOPOLOGY_DISRUPTOR_WAIT_STRATEGY_SCHEMA = String.class;
-    
+
    /**
     * The size of the shared thread pool for worker tasks to make use of. The thread pool can be accessed 
     * via the TopologyContext.
@@ -766,21 +694,21 @@ public class Config extends HashMap<String, Object> {
     /**
      * Name of the topology. This config is automatically set by Storm when the topology is submitted.
      */
-    public static final String TOPOLOGY_NAME="topology.name";  
+    public static final String TOPOLOGY_NAME="topology.name";
     public static final Object TOPOLOGY_NAME_SCHEMA = String.class;
-    
+
     /**
      * The root directory in ZooKeeper for metadata about TransactionalSpouts.
      */
     public static final String TRANSACTIONAL_ZOOKEEPER_ROOT="transactional.zookeeper.root";
     public static final Object TRANSACTIONAL_ZOOKEEPER_ROOT_SCHEMA = String.class;
-    
+
     /**
      * The list of zookeeper servers in which to keep the transactional state. If null (which is default),
      * will use storm.zookeeper.servers
      */
     public static final String TRANSACTIONAL_ZOOKEEPER_SERVERS="transactional.zookeeper.servers";
-    public static final Object TRANSACTIONAL_ZOOKEEPER_SERVERS_SCHEMA = StringsValidator;
+    public static final Object TRANSACTIONAL_ZOOKEEPER_SERVERS_SCHEMA = ConfigValidation.StringsValidator;
 
     /**
      * The port to use to connect to the transactional zookeeper servers. If null (which is default),
@@ -788,7 +716,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String TRANSACTIONAL_ZOOKEEPER_PORT="transactional.zookeeper.port";
     public static final Object TRANSACTIONAL_ZOOKEEPER_PORT_SCHEMA = Number.class;
-    
+
     /**
      * The number of threads that should be used by the zeromq context in each worker process.
      */
@@ -809,7 +737,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String ZMQ_HWM = "zmq.hwm";
     public static final Object ZMQ_HWM_SCHEMA = Number.class;
-        
+
     /**
      * This value is passed to spawned JVMs (e.g., Nimbus, Supervisor, and Workers)
      * for the java.library.path value. java.library.path tells the JVM where 
@@ -818,7 +746,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String JAVA_LIBRARY_PATH = "java.library.path";
     public static final Object JAVA_LIBRARY_PATH_SCHEMA = String.class;
-    
+
     /**
      * The path to use as the zookeeper dir when running a zookeeper server via
      * "storm dev-zookeeper". This zookeeper instance is only intended for development;
@@ -826,7 +754,7 @@ public class Config extends HashMap<String, Object> {
      */
     public static final String DEV_ZOOKEEPER_PATH = "dev.zookeeper.path";
     public static final Object DEV_ZOOKEEPER_PATH_SCHEMA = String.class;
-    
+
     /**
      * A map from topology name to the number of machines that should be dedicated for that topology. Set storm.scheduler
      * to backtype.storm.scheduler.IsolationScheduler to make use of the isolation scheduler.

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -105,25 +105,25 @@ public class Config extends HashMap<String, Object> {
     /**
      * Netty based messaging: The buffer size for send/recv buffer
      */
-    public static String STORM_MESSAGING_NETTY_BUFFER_SIZE = "storm.messaging.netty.buffer_size"; 
+    public static final String STORM_MESSAGING_NETTY_BUFFER_SIZE = "storm.messaging.netty.buffer_size"; 
     public static final Object STORM_MESSAGING_NETTY_BUFFER_SIZE_SCHEMA = Number.class;
 
     /**
      * Netty based messaging: The max # of retries that a peer will perform when a remote is not accessible
      */
-    public static String STORM_MESSAGING_NETTY_MAX_RETRIES = "storm.messaging.netty.max_retries"; 
+    public static final String STORM_MESSAGING_NETTY_MAX_RETRIES = "storm.messaging.netty.max_retries"; 
     public static final Object STORM_MESSAGING_NETTY_MAX_RETRIES_SCHEMA = Number.class;
 
     /**
      * Netty based messaging: The min # of milliseconds that a peer will wait. 
      */
-    public static String STORM_MESSAGING_NETTY_MIN_SLEEP_MS = "storm.messaging.netty.min_wait_ms"; 
+    public static final String STORM_MESSAGING_NETTY_MIN_SLEEP_MS = "storm.messaging.netty.min_wait_ms"; 
     public static final Object STORM_MESSAGING_NETTY_MIN_SLEEP_MS_SCHEMA = Number.class;
 
     /**
      * Netty based messaging: The max # of milliseconds that a peer will wait. 
      */
-    public static String STORM_MESSAGING_NETTY_MAX_SLEEP_MS = "storm.messaging.netty.max_wait_ms"; 
+    public static final String STORM_MESSAGING_NETTY_MAX_SLEEP_MS = "storm.messaging.netty.max_wait_ms"; 
     public static final Object STORM_MESSAGING_NETTY_MAX_SLEEP_MS_SCHEMA = Number.class;
 
     /**

--- a/storm-core/src/jvm/backtype/storm/ConfigValidation.java
+++ b/storm-core/src/jvm/backtype/storm/ConfigValidation.java
@@ -1,0 +1,82 @@
+package backtype.storm;
+
+/**
+ * Provides functionality for validating configuration fields.
+ */
+public class ConfigValidation {
+
+    /**
+     * Declares methods for validating configuration values.
+     */
+    public static interface FieldValidator {
+        /**
+         * Validates the given field.
+         * @param field The field to be validated.
+         * @throws IllegalArgumentException if the field fails validation.
+         */
+        public void validateField(Object field) throws IllegalArgumentException;
+    }
+
+    /**
+     * Returns a new FieldValidator for a List of the given Class.
+     * @param cls the Class of elements composing the list
+     * @return a FieldValidator for a list of the given class
+     */
+    static FieldValidator FieldListValidatorFactory(final Class cls) {
+        return new FieldValidator() {
+            @Override
+            public void validateField(Object field)
+                    throws IllegalArgumentException {
+                if (field == null) {
+                    // A null value is acceptable.
+                    return;
+                }
+                if (field instanceof Iterable) {
+                    for (Object e : (Iterable)field) {
+                        if (! cls.isInstance(e)) {
+                            throw new IllegalArgumentException(
+                                    "Each element of this list must be a " +
+                                    cls.getName() + ".");
+                        }
+                    }
+                    return;
+                }
+                throw new IllegalArgumentException(
+                        "Field must be an Iterable of " + cls.getName());
+            }
+        };
+    }
+
+    /**
+     * Validates a list of Numbers.
+     */
+    public static Object NumbersValidator = FieldListValidatorFactory(Number.class);
+
+    /**
+     * Validates is a list of Strings.
+     */
+    public static Object StringsValidator = FieldListValidatorFactory(String.class);
+
+    /**
+     * Validates a power of 2.
+     */
+    public static Object PowerOf2Validator = new FieldValidator() {
+        @Override
+        public void validateField(Object o) throws IllegalArgumentException {
+            if (o == null) {
+                // A null value is acceptable.
+                return;
+            }
+            final long i;
+            if (o instanceof Number &&
+                    (i = ((Number)o).longValue()) == ((Number)o).doubleValue())
+            {
+                // Test whether the integer is a power of 2.
+                if (i > 0 && (i & (i-1)) == 0) {
+                    return;
+                }
+            }
+            throw new IllegalArgumentException("Field must be a power of 2.");
+        }
+    };
+}

--- a/storm-core/test/clj/backtype/storm/config_test.clj
+++ b/storm-core/test/clj/backtype/storm/config_test.clj
@@ -1,10 +1,55 @@
 (ns backtype.storm.config-test
+  (:import [backtype.storm Config ConfigValidation])
+  (:import [backtype.storm.scheduler TopologyDetails])
   (:import [backtype.storm.utils Utils])
   (:use [clojure test])
-  (:use [backtype.storm config])
+  (:use [backtype.storm config util])
   )
 
 (deftest test-validity
   (is (Utils/isValidConf {TOPOLOGY-DEBUG true "q" "asasdasd" "aaa" (Integer. "123") "bbb" (Long. "456") "eee" [1 2 (Integer. "3") (Long. "4")]}))
   (is (not (Utils/isValidConf {"qqq" (backtype.storm.utils.Utils.)})))
   )
+
+(deftest test-power-of-2-validator
+  (let [validator ConfigValidation/PowerOf2Validator]
+    (doseq [x [42.42 42 23423423423 -33 -32 -1 -0.00001 0 -0 "Forty-two"]]
+      (is (thrown-cause? java.lang.IllegalArgumentException
+        (.validateField validator x))))
+
+    (doseq [x [64 4294967296 1 nil]]
+      (.validateField validator x))))
+
+(deftest test-list-validator
+  (let [validator ConfigValidation/StringsValidator]
+    (doseq [x [
+               ["Forty-two" 42]
+               [42]
+               [true "false"]
+               [nil]
+               [nil "nil"]
+              ]]
+      (is (thrown-cause-with-msg?
+            java.lang.IllegalArgumentException #"(?i).*each element.*"
+        (.validateField validator x))))
+
+    (doseq [x ["not a list at all"]]
+      (is (thrown-cause-with-msg?
+            java.lang.IllegalArgumentException #"(?i).*must be an iterable.*"
+        (.validateField validator x))))
+
+    (doseq [x [
+               ["one" "two" "three"]
+               [""]
+               ["42" "64"]
+               nil
+              ]]
+      (.validateField validator x))))
+
+(deftest test-topology-workers-is-number
+  (let [validator (CONFIG-SCHEMA-MAP TOPOLOGY-WORKERS)]
+    (.validateField validator 42)
+    ;; The float can be rounded down to an int.
+    (.validateField validator 3.14159)
+    (is (thrown-cause? java.lang.IllegalArgumentException
+      (.validateField validator "42")))))


### PR DESCRIPTION
For issue #581

This pull request supersedes #582

This is a prototype implementation to continue along the path suggested in this comment https://github.com/nathanmarz/storm/pull/582#issuecomment-18880232

Adds a schema to each config, and validates on reading the config yaml.

Just looking for comments and direction at this point.

TODO:
- There should be a single validation function: `validate-configs-with-schemas` should just call this function and not have to test for `nil` or `instanceof FieldValidator`.  The mapping created in `b.s.config` should map the field value to this function instead of to the schema.
- We should validate on `findAndReadConfigFile`, and not on `readStormConfig`, since it will unnecessarily validate the defaults.yaml.  (It is currently there for testing.)
- Some of the types are not sufficient.  Some cases of `java.lang.Number` might need to be `Integer` instead
- Some reorganization of code (Do we want `FieldValidator`s in `Config`?)
- Lots of code intended for debugging needs to be removed.
