### PR TITLE
add straightforward fixed-size pooling for DRPCClients and DRPCInvocationClients

### DIFF
--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -40,7 +40,7 @@
              :lib {}
              }
 
-  :plugins [[lein-swank "1.4.4"]]
+  :plugins [[lein-swank "1.4.4"][lein-idea "1.0.1"]]
 
   :repositories {"sonatype"
                  "http://oss.sonatype.org/content/groups/public/"}

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -3,6 +3,7 @@ package backtype.storm;
 import backtype.storm.serialization.IKryoDecorator;
 import backtype.storm.serialization.IKryoFactory;
 import com.esotericsoftware.kryo.Serializer;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -73,6 +74,12 @@ public class Config extends HashMap<String, Object> {
      * If this is not set, a default system scheduler will be used.
      */
     public static final String STORM_SCHEDULER = "storm.scheduler";
+
+    /**
+     * Whether this Storm cluster is using local drpc.  Either "true" or "false".  If not set,
+     * STORM_CLUSTER_MODE is checked whether or not it is local.
+     */
+    public static final String STORM_CLUSTER_DRPC_IS_LOCAL = "storm.cluster.drpc.is.local";
 
     /**
      * The mode this Storm cluster is running in. Either "distributed" or "local".

--- a/storm-core/src/jvm/backtype/storm/drpc/AbstractFixedSizePool.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/AbstractFixedSizePool.java
@@ -1,0 +1,43 @@
+package backtype.storm.drpc;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+public abstract class AbstractFixedSizePool<T> {
+
+    public static Logger LOG = LoggerFactory.getLogger(AbstractFixedSizePool.class);
+
+    protected final BlockingQueue<T> queue;
+
+    protected AbstractFixedSizePool(int capacity) {
+        this.queue = new LinkedBlockingQueue<T>(capacity);
+    }
+
+    protected T take() {
+        try {
+            return queue.take();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected T take(int timeout, TimeUnit timeUnit) {
+        try {
+            return queue.poll(timeout, timeUnit);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected void put(T client) {
+        try {
+            queue.put(client);
+        } catch (InterruptedException e) {
+            LOG.warn("InterruptedException caught during finally clause; swallowing: ", e);
+        }
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocations.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocations.java
@@ -1,0 +1,13 @@
+package backtype.storm.drpc;
+
+import backtype.storm.generated.DistributedRPCInvocations;
+
+public interface DRPCInvocations extends DistributedRPCInvocations.Iface {
+
+    void close();
+
+    int getPort();
+
+    String getHost();
+
+}

--- a/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocationsClient.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocationsClient.java
@@ -8,23 +8,37 @@ import org.apache.thrift7.transport.TFramedTransport;
 import org.apache.thrift7.transport.TSocket;
 import org.apache.thrift7.transport.TTransport;
 
-public class DRPCInvocationsClient implements DistributedRPCInvocations.Iface {
-    private TTransport conn;
-    private DistributedRPCInvocations.Client client;
-    private String host;
-    private int port;    
+public class DRPCInvocationsClient implements DRPCInvocations {
+    protected TTransport conn;
+    protected DistributedRPCInvocations.Client client;
+    protected String host;
+    protected int port;
 
     public DRPCInvocationsClient(String host, int port) {
+        this(host, port, true);
+    }
+
+    public DRPCInvocationsClient(String host, int port, boolean connectImmediately) {
         try {
             this.host = host;
             this.port = port;
-            connect();
+            if (connectImmediately)
+                connect();
         } catch(TException e) {
             throw new RuntimeException(e);
         }
     }
-    
-    private void connect() throws TException {
+
+    protected void ensureConnected() throws TException {
+        if (!isConnected())
+            connect();
+    }
+
+    protected boolean isConnected() {
+        return conn != null && conn.isOpen();
+    }
+
+    protected void connect() throws TException {
         conn = new TFramedTransport(new TSocket(host, port));
         client = new DistributedRPCInvocations.Client(new TBinaryProtocol(conn));
         conn.open();
@@ -40,35 +54,51 @@ public class DRPCInvocationsClient implements DistributedRPCInvocations.Iface {
 
     public void result(String id, String result) throws TException {
         try {
-            if(client==null) connect();
-            client.result(id, result);
+            doResult(id, result);
         } catch(TException e) {
-            client = null;
+            close();
             throw e;
         }
+    }
+
+    protected void doResult(String id, String result) throws TException {
+        ensureConnected();
+        client.result(id, result);
     }
 
     public DRPCRequest fetchRequest(String func) throws TException {
         try {
-            if(client==null) connect();
-            return client.fetchRequest(func);
+            return doFetchRequest(func);
         } catch(TException e) {
-            client = null;
-            throw e;
-        }
-    }    
-
-    public void failRequest(String id) throws TException {
-        try {
-            if(client==null) connect();
-            client.failRequest(id);
-        } catch(TException e) {
-            client = null;
+            close();
             throw e;
         }
     }
 
+    protected DRPCRequest doFetchRequest(String func) throws TException {
+        ensureConnected();
+        return client.fetchRequest(func);
+    }
+
+    public void failRequest(String id) throws TException {
+        try {
+            doFailRequest(id);
+        } catch(TException e) {
+            close();
+            throw e;
+        }
+    }
+
+    protected void doFailRequest(String id) throws TException {
+        ensureConnected();
+        client.failRequest(id);
+    }
+
     public void close() {
-        conn.close();
+        if (conn != null) {
+            conn.close();
+            conn = null;
+        }
+        client = null;
     }
 }

--- a/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocationsClientFactory.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocationsClientFactory.java
@@ -1,0 +1,12 @@
+package backtype.storm.drpc;
+
+import com.google.common.net.HostAndPort;
+
+public class DRPCInvocationsClientFactory implements DRPCInvocationsFactory {
+
+    @Override
+    public DRPCInvocations getClientForServer(HostAndPort hostAndPort) {
+        return new DRPCInvocationsClient(hostAndPort.getHostText(), hostAndPort.getPort());
+    }
+
+}

--- a/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocationsFactory.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/DRPCInvocationsFactory.java
@@ -1,0 +1,11 @@
+package backtype.storm.drpc;
+
+import com.google.common.net.HostAndPort;
+
+import java.io.Serializable;
+
+public interface DRPCInvocationsFactory extends Serializable {
+
+    DRPCInvocations getClientForServer(HostAndPort hostAndPort);
+
+}

--- a/storm-core/src/jvm/backtype/storm/drpc/DRPCSpout.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/DRPCSpout.java
@@ -3,79 +3,86 @@ package backtype.storm.drpc;
 import backtype.storm.Config;
 import backtype.storm.ILocalDRPC;
 import backtype.storm.generated.DRPCRequest;
-import backtype.storm.generated.DistributedRPCInvocations;
 import backtype.storm.spout.SpoutOutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.topology.base.BaseRichSpout;
 import backtype.storm.tuple.Fields;
 import backtype.storm.tuple.Values;
-import backtype.storm.utils.ServiceRegistry;
 import backtype.storm.utils.Utils;
+import com.google.common.net.HostAndPort;
+import org.apache.thrift7.TException;
+import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.thrift7.TException;
-import org.json.simple.JSONValue;
 
 public class DRPCSpout extends BaseRichSpout {
     public static Logger LOG = LoggerFactory.getLogger(DRPCSpout.class);
-    
-    SpoutOutputCollector _collector;
-    List<DRPCInvocationsClient> _clients = new ArrayList<DRPCInvocationsClient>();
-    String _function;
-    String _local_drpc_id = null;
-    
-    private static class DRPCMessageId {
+
+    protected SpoutOutputCollector _collector;
+    protected List<DRPCInvocations> _clients = new ArrayList<DRPCInvocations>();
+    protected String _function;
+    public final DRPCInvocationsFactory _factory;
+
+    protected static class DRPCMessageId {
         String id;
         int index;
-        
+
         public DRPCMessageId(String id, int index) {
             this.id = id;
             this.index = index;
         }
     }
-    
-    
+
+
     public DRPCSpout(String function) {
-        _function = function;
+        this(function, new DRPCInvocationsClientFactory());
     }
 
+    @Deprecated
     public DRPCSpout(String function, ILocalDRPC drpc) {
-        _function = function;
-        _local_drpc_id = drpc.getServiceId();
+        this(function, new LocalDRPCInvocationFactory(drpc));
     }
-    
+
+    public DRPCSpout(String function, DRPCInvocationsFactory factory) {
+        this._factory = factory;
+        this._function = function;
+    }
+
     @Override
     public void open(Map conf, TopologyContext context, SpoutOutputCollector collector) {
         _collector = collector;
-        if(_local_drpc_id==null) {
-            int numTasks = context.getComponentTasks(context.getThisComponentId()).size();
-            int index = context.getThisTaskIndex();
+        initializeDRPCInvocationClients(conf, context);
+    }
 
-            int port = Utils.getInt(conf.get(Config.DRPC_INVOCATIONS_PORT));
-            List<String> servers = (List<String>) conf.get(Config.DRPC_SERVERS);
-            if(servers == null || servers.isEmpty()) {
-                throw new RuntimeException("No DRPC servers configured for topology");   
-            }
-            if(numTasks < servers.size()) {
-                for(String s: servers) {
-                    _clients.add(new DRPCInvocationsClient(s, port));
-                }
-            } else {
-                int i = index % servers.size();
-                _clients.add(new DRPCInvocationsClient(servers.get(i), port));
-            }
+    protected void initializeDRPCInvocationClients(Map conf, TopologyContext context) {
+        int numTasks = context.getComponentTasks(context.getThisComponentId()).size();
+        int index = context.getThisTaskIndex();
+
+        int port = Utils.getInt(conf.get(Config.DRPC_INVOCATIONS_PORT));
+        List<String> servers = (List<String>) conf.get(Config.DRPC_SERVERS);
+        if (servers == null || servers.isEmpty()) {
+            throw new RuntimeException("No DRPC servers configured for topology. Local DRPC should add 'localhost'");
         }
-        
+        if (numTasks < servers.size()) {
+            for (String s : servers) {
+                HostAndPort hostAndPort = HostAndPort.fromParts(s, port);
+                _clients.add(_factory.getClientForServer(hostAndPort));
+            }
+        } else {
+            int i = index % servers.size();
+            _clients.add(_factory.getClientForServer(HostAndPort.fromParts(servers.get(i), port)));
+        }
     }
 
     @Override
     public void close() {
-        for(DRPCInvocationsClient client: _clients) {
+        for (DRPCInvocations client : _clients) {
             client.close();
         }
     }
@@ -83,43 +90,24 @@ public class DRPCSpout extends BaseRichSpout {
     @Override
     public void nextTuple() {
         boolean gotRequest = false;
-        if(_local_drpc_id==null) {
-            for(int i=0; i<_clients.size(); i++) {
-                DRPCInvocationsClient client = _clients.get(i);
-                try {
-                    DRPCRequest req = client.fetchRequest(_function);
-                    if(req.get_request_id().length() > 0) {
-                        Map returnInfo = new HashMap();
-                        returnInfo.put("id", req.get_request_id());
-                        returnInfo.put("host", client.getHost());
-                        returnInfo.put("port", client.getPort());
-                        gotRequest = true;
-                        _collector.emit(new Values(req.get_func_args(), JSONValue.toJSONString(returnInfo)), new DRPCMessageId(req.get_request_id(), i));
-                        break;
-                    }
-                } catch (TException e) {
-                    LOG.error("Failed to fetch DRPC result from DRPC server", e);
+        for (int i = 0; i < _clients.size(); i++) {
+            DRPCInvocations client = _clients.get(i);
+            try {
+                DRPCRequest req = client.fetchRequest(_function);
+                if (req.get_request_id().length() > 0) {
+                    Map returnInfo = new HashMap();
+                    returnInfo.put("id", req.get_request_id());
+                    returnInfo.put("host", client.getHost());
+                    returnInfo.put("port", client.getPort());
+                    gotRequest = true;
+                    _collector.emit(new Values(req.get_func_args(), JSONValue.toJSONString(returnInfo)), new DRPCMessageId(req.get_request_id(), i));
+                    break;
                 }
-            }
-        } else {
-            DistributedRPCInvocations.Iface drpc = (DistributedRPCInvocations.Iface) ServiceRegistry.getService(_local_drpc_id);
-            if(drpc!=null) { // can happen during shutdown of drpc while topology is still up
-                try {
-                    DRPCRequest req = drpc.fetchRequest(_function);
-                    if(req.get_request_id().length() > 0) {
-                        Map returnInfo = new HashMap();
-                        returnInfo.put("id", req.get_request_id());
-                        returnInfo.put("host", _local_drpc_id);
-                        returnInfo.put("port", 0);
-                        gotRequest = true;
-                        _collector.emit(new Values(req.get_func_args(), JSONValue.toJSONString(returnInfo)), new DRPCMessageId(req.get_request_id(), 0));
-                    }
-                } catch (TException e) {
-                    throw new RuntimeException(e);
-                }
+            } catch (TException e) {
+                LOG.error("Failed to fetch DRPC result from DRPC server", e);
             }
         }
-        if(!gotRequest) {
+        if (!gotRequest) {
             Utils.sleep(1);
         }
     }
@@ -131,13 +119,7 @@ public class DRPCSpout extends BaseRichSpout {
     @Override
     public void fail(Object msgId) {
         DRPCMessageId did = (DRPCMessageId) msgId;
-        DistributedRPCInvocations.Iface client;
-        
-        if(_local_drpc_id == null) {
-            client = _clients.get(did.index);
-        } else {
-            client = (DistributedRPCInvocations.Iface) ServiceRegistry.getService(_local_drpc_id);
-        }
+        DRPCInvocations client = _clients.get(did.index);
         try {
             client.failRequest(did.id);
         } catch (TException e) {
@@ -148,5 +130,5 @@ public class DRPCSpout extends BaseRichSpout {
     @Override
     public void declareOutputFields(OutputFieldsDeclarer declarer) {
         declarer.declare(new Fields("args", "return-info"));
-    }    
+    }
 }

--- a/storm-core/src/jvm/backtype/storm/drpc/FixedSizeDRPCInvocationsClientPool.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/FixedSizeDRPCInvocationsClientPool.java
@@ -1,0 +1,140 @@
+package backtype.storm.drpc;
+
+import backtype.storm.generated.DRPCRequest;
+import com.google.common.net.HostAndPort;
+import org.apache.thrift7.TException;
+import org.apache.thrift7.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FixedSizeDRPCInvocationsClientPool extends AbstractFixedSizePool<FixedSizeDRPCInvocationsClientPool.RetryConnectionOnceDRPCInvocationsClient> implements DRPCInvocations {
+
+    public static Logger LOG = LoggerFactory.getLogger(FixedSizeDRPCInvocationsClientPool.class);
+
+    public final HostAndPort hostAndPort;
+
+    public FixedSizeDRPCInvocationsClientPool(HostAndPort hostAndPort, int connections, boolean connectImmediately) {
+        super(connections);
+        this.hostAndPort = hostAndPort;
+        for (int i = 0; i < connections; ++i)
+            queue.add(createClient(connectImmediately));
+    }
+
+    private RetryConnectionOnceDRPCInvocationsClient createClient(boolean connectImmediately) {
+        RetryConnectionOnceDRPCInvocationsClient client = new RetryConnectionOnceDRPCInvocationsClient(hostAndPort.getHostText(),
+                hostAndPort.getPort(), false);
+        // We don't want the DRPC client's being unavailable to stop client startup, so connect in a separate step.
+        if (connectImmediately) {
+            try {
+                client.ensureConnected();
+            } catch (TException e) {
+                LOG.warn("Unable to eagerly connect to {}, leaving in unconnected state: ", hostAndPort, e);
+                client.close();
+            }
+        }
+        return client;
+    }
+
+    @Override
+    public synchronized void close() {
+        final int connections = queue.size();
+        Set<RetryConnectionOnceDRPCInvocationsClient> set = new HashSet<RetryConnectionOnceDRPCInvocationsClient>(connections);
+        while (set.size() != connections) {
+            queue.drainTo(set);
+        }
+        for (RetryConnectionOnceDRPCInvocationsClient client : set) {
+            try {
+                client.close();
+            } catch (Exception e) {
+                LOG.warn("Error encountered closing connection to {}, ignoring: ", hostAndPort, e);
+            }
+        }
+        queue.addAll(set);
+    }
+
+    @Override
+    public int getPort() {
+        return hostAndPort.getPort();
+    }
+
+    @Override
+    public String getHost() {
+        return hostAndPort.getHostText();
+    }
+
+    @Override
+    public void result(String id, String result) throws TException {
+        RetryConnectionOnceDRPCInvocationsClient client = take();
+        try {
+            client.result(id, result);
+        } finally {
+            put(client);
+        }
+    }
+
+    @Override
+    public DRPCRequest fetchRequest(String functionName) throws TException {
+        RetryConnectionOnceDRPCInvocationsClient client = take();
+        try {
+            return client.fetchRequest(functionName);
+        } finally {
+            put(client);
+        }
+    }
+
+    @Override
+    public void failRequest(String id) throws TException {
+        RetryConnectionOnceDRPCInvocationsClient client = take();
+        try {
+            client.failRequest(id);
+        } finally {
+            put(client);
+        }
+    }
+
+    public static class RetryConnectionOnceDRPCInvocationsClient extends DRPCInvocationsClient {
+
+        public RetryConnectionOnceDRPCInvocationsClient(String host, int port, boolean connectImmediately) {
+            super(host, port, connectImmediately);
+        }
+
+        @Override
+        protected void doFailRequest(String id) throws TException {
+            try {
+                super.doFailRequest(id);
+            } catch (TTransportException e) {
+                // We'll catch the first transport-related connection (timeout, reconnect, whatever) and retry
+                LOG.debug("Caught transport exception failing request; reconnecting and re-trying: ", e);
+                close();
+                super.doFailRequest(id);
+            }
+        }
+
+        @Override
+        protected DRPCRequest doFetchRequest(String func) throws TException {
+            try {
+                return super.doFetchRequest(func);
+            } catch (TTransportException e) {
+                // We'll catch the first transport-related connection (timeout, reconnect, whatever) and retry
+                LOG.debug("Caught transport exception during fetch; reconnecting and re-trying: ", e);
+                close();
+                return super.doFetchRequest(func);
+            }
+        }
+
+        @Override
+        protected void doResult(String id, String result) throws TException {
+            try {
+                super.doResult(id, result);
+            } catch (TTransportException e) {
+                // We'll catch the first transport-related connection (timeout, reconnect, whatever) and retry
+                LOG.debug("Caught transport exception returning result; reconnecting and re-trying: ", e);
+                close();
+                super.doResult(id, result);
+            }
+        }
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/drpc/FixedSizeDRPCInvocationsClientPoolFactory.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/FixedSizeDRPCInvocationsClientPoolFactory.java
@@ -1,0 +1,35 @@
+package backtype.storm.drpc;
+
+import com.google.common.net.HostAndPort;
+
+import java.io.Serializable;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FixedSizeDRPCInvocationsClientPoolFactory implements Serializable, DRPCInvocationsFactory {
+
+    private final ConcurrentHashMap<HostAndPort, FixedSizeDRPCInvocationsClientPool> serverMap =
+            new ConcurrentHashMap<HostAndPort, FixedSizeDRPCInvocationsClientPool>();
+
+    private final boolean connectImmediately;
+    private final int connections;
+
+    public FixedSizeDRPCInvocationsClientPoolFactory(int connections, boolean connectImmediately) {
+        this.connectImmediately = connectImmediately;
+        this.connections = connections;
+    }
+
+    @Override
+    public DRPCInvocations getClientForServer(HostAndPort hostAndPort) {
+        FixedSizeDRPCInvocationsClientPool pool = serverMap.get(hostAndPort);
+        if (pool == null) {
+            pool = new FixedSizeDRPCInvocationsClientPool(hostAndPort, connections, connectImmediately);
+            FixedSizeDRPCInvocationsClientPool ret = serverMap.putIfAbsent(hostAndPort, pool);
+            if (ret != null) {
+                pool.close();
+                pool = ret;
+            }
+        }
+        return pool;
+    }
+
+}

--- a/storm-core/src/jvm/backtype/storm/drpc/LinearDRPCTopologyBuilder.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/LinearDRPCTopologyBuilder.java
@@ -11,15 +11,9 @@ import backtype.storm.coordination.IBatchBolt;
 import backtype.storm.generated.StormTopology;
 import backtype.storm.generated.StreamInfo;
 import backtype.storm.grouping.CustomStreamGrouping;
-import backtype.storm.topology.BaseConfigurationDeclarer;
-import backtype.storm.topology.BasicBoltExecutor;
-import backtype.storm.topology.BoltDeclarer;
-import backtype.storm.topology.IBasicBolt;
-import backtype.storm.topology.IRichBolt;
-import backtype.storm.topology.InputDeclarer;
-import backtype.storm.topology.OutputFieldsGetter;
-import backtype.storm.topology.TopologyBuilder;
+import backtype.storm.topology.*;
 import backtype.storm.tuple.Fields;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -67,7 +61,7 @@ public class LinearDRPCTopologyBuilder {
     }
         
     public StormTopology createLocalTopology(ILocalDRPC drpc) {
-        return createTopology(new DRPCSpout(_function, drpc));
+        return createTopology(new DRPCSpout(_function, new LocalDRPCInvocationFactory(drpc)));
     }
     
     public StormTopology createRemoteTopology() {
@@ -144,7 +138,7 @@ public class LinearDRPCTopologyBuilder {
                 .fieldsGrouping(boltId(i-1), outputStream, new Fields(fields.get(0)))
                 .fieldsGrouping(PREPARE_ID, PrepareRequest.RETURN_STREAM, new Fields("request"));
         i++;
-        builder.setBolt(boltId(i), new ReturnResults())
+        builder.setBolt(boltId(i), new ReturnResults(spout._factory))
                 .noneGrouping(boltId(i-1));
         return builder.createTopology();
     }

--- a/storm-core/src/jvm/backtype/storm/drpc/LocalDRPCInvocationFactory.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/LocalDRPCInvocationFactory.java
@@ -1,0 +1,72 @@
+package backtype.storm.drpc;
+
+import backtype.storm.ILocalDRPC;
+import backtype.storm.generated.DRPCRequest;
+import backtype.storm.generated.DistributedRPCInvocations;
+import backtype.storm.utils.ServiceRegistry;
+import com.google.common.net.HostAndPort;
+import org.apache.thrift7.TException;
+
+import static org.apache.commons.lang.StringUtils.isBlank;
+
+public class LocalDRPCInvocationFactory implements DRPCInvocationsFactory {
+
+    protected final String localDrpcId;
+
+    public LocalDRPCInvocationFactory() {
+        localDrpcId = null;
+    }
+
+    public LocalDRPCInvocationFactory(ILocalDRPC drpc) {
+        localDrpcId = drpc.getServiceId();
+    }
+
+    @Override
+    public DRPCInvocations getClientForServer(HostAndPort hostAndPort) {
+        String host = hostAndPort.getHostText();
+        if (!isBlank(localDrpcId) && !localDrpcId.equals(host)) {
+            throw new IllegalStateException("Mismatched local drpc ids: " + localDrpcId + ", " + hostAndPort);
+        }
+        return new LocalDRPCInvocationClient((DRPCInvocations) ServiceRegistry.getService(host), host);
+    }
+
+    private static class LocalDRPCInvocationClient implements DRPCInvocations {
+
+        final DistributedRPCInvocations.Iface delegate;
+        final String localDrpcId;
+
+        private LocalDRPCInvocationClient(DRPCInvocations delegate, String localDrpcId) {
+            this.delegate = delegate;
+            this.localDrpcId = localDrpcId;
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public int getPort() {
+            return 0;
+        }
+
+        @Override
+        public String getHost() {
+            return localDrpcId;
+        }
+
+        @Override
+        public void result(String id, String result) throws TException {
+                delegate.result(id, result);
+        }
+
+        @Override
+        public DRPCRequest fetchRequest(String functionName) throws TException {
+            return delegate.fetchRequest(functionName);
+        }
+
+        @Override
+        public void failRequest(String id) throws TException {
+                delegate.failRequest(id);
+        }
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/drpc/LocalDRPCInvocationFactory.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/LocalDRPCInvocationFactory.java
@@ -17,7 +17,7 @@ public class LocalDRPCInvocationFactory implements DRPCInvocationsFactory {
 
     @Override
     public DRPCInvocations getClientForServer(HostAndPort hostAndPort) {
-        return new LocalDRPCInvocationClient((DRPCInvocations) ServiceRegistry.getService(localDrpcId), hostAndPort);
+        return new LocalDRPCInvocationClient((DistributedRPCInvocations.Iface) ServiceRegistry.getService(localDrpcId), hostAndPort);
     }
 
     private static class LocalDRPCInvocationClient implements DRPCInvocations {
@@ -25,7 +25,7 @@ public class LocalDRPCInvocationFactory implements DRPCInvocationsFactory {
         final DistributedRPCInvocations.Iface delegate;
         final HostAndPort hostAndPort;
 
-        private LocalDRPCInvocationClient(DRPCInvocations delegate, HostAndPort hostAndPort) {
+        private LocalDRPCInvocationClient(DistributedRPCInvocations.Iface delegate, HostAndPort hostAndPort) {
             this.delegate = delegate;
             this.hostAndPort = hostAndPort;
         }

--- a/storm-core/src/jvm/backtype/storm/drpc/LocalDRPCInvocationFactory.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/LocalDRPCInvocationFactory.java
@@ -7,15 +7,9 @@ import backtype.storm.utils.ServiceRegistry;
 import com.google.common.net.HostAndPort;
 import org.apache.thrift7.TException;
 
-import static org.apache.commons.lang.StringUtils.isBlank;
-
 public class LocalDRPCInvocationFactory implements DRPCInvocationsFactory {
 
     protected final String localDrpcId;
-
-    public LocalDRPCInvocationFactory() {
-        localDrpcId = null;
-    }
 
     public LocalDRPCInvocationFactory(ILocalDRPC drpc) {
         localDrpcId = drpc.getServiceId();
@@ -23,21 +17,17 @@ public class LocalDRPCInvocationFactory implements DRPCInvocationsFactory {
 
     @Override
     public DRPCInvocations getClientForServer(HostAndPort hostAndPort) {
-        String host = hostAndPort.getHostText();
-        if (!isBlank(localDrpcId) && !localDrpcId.equals(host)) {
-            throw new IllegalStateException("Mismatched local drpc ids: " + localDrpcId + ", " + hostAndPort);
-        }
-        return new LocalDRPCInvocationClient((DRPCInvocations) ServiceRegistry.getService(host), host);
+        return new LocalDRPCInvocationClient((DRPCInvocations) ServiceRegistry.getService(localDrpcId), hostAndPort);
     }
 
     private static class LocalDRPCInvocationClient implements DRPCInvocations {
 
         final DistributedRPCInvocations.Iface delegate;
-        final String localDrpcId;
+        final HostAndPort hostAndPort;
 
-        private LocalDRPCInvocationClient(DRPCInvocations delegate, String localDrpcId) {
+        private LocalDRPCInvocationClient(DRPCInvocations delegate, HostAndPort hostAndPort) {
             this.delegate = delegate;
-            this.localDrpcId = localDrpcId;
+            this.hostAndPort = hostAndPort;
         }
 
         @Override
@@ -46,12 +36,12 @@ public class LocalDRPCInvocationFactory implements DRPCInvocationsFactory {
 
         @Override
         public int getPort() {
-            return 0;
+            return hostAndPort.getPort();
         }
 
         @Override
         public String getHost() {
-            return localDrpcId;
+            return hostAndPort.getHostText();
         }
 
         @Override

--- a/storm-core/src/jvm/backtype/storm/drpc/ReturnResults.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/ReturnResults.java
@@ -1,74 +1,90 @@
 package backtype.storm.drpc;
 
 import backtype.storm.Config;
-import backtype.storm.generated.DistributedRPCInvocations;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
 import backtype.storm.topology.base.BaseRichBolt;
 import backtype.storm.tuple.Tuple;
-import backtype.storm.utils.ServiceRegistry;
 import backtype.storm.utils.Utils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.google.common.net.HostAndPort;
 import org.apache.thrift7.TException;
 import org.json.simple.JSONValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 
 public class ReturnResults extends BaseRichBolt {
     public static final Logger LOG = LoggerFactory.getLogger(ReturnResults.class);
-    OutputCollector _collector;
-    boolean local;
 
-    Map<List, DRPCInvocationsClient> _clients = new HashMap<List, DRPCInvocationsClient>();
+    protected OutputCollector _collector;
+    protected DRPCInvocationsFactory _factory;
+
+    protected Map<HostAndPort, DRPCInvocations> _clients = new HashMap<HostAndPort, DRPCInvocations>();
+
+    @Deprecated
+    public ReturnResults() {
+    }
+
+    public ReturnResults(DRPCInvocationsFactory factory) {
+        this._factory = factory;
+    }
 
     @Override
     public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
         _collector = collector;
-        local = stormConf.get(Config.STORM_CLUSTER_MODE).equals("local");
+        // Yuck.  Would happily ditch this if backwards compatibility is not an issue.
+        if (_factory == null) {
+            String localDrpcString = (String) stormConf.get(Config.STORM_CLUSTER_DRPC_IS_LOCAL);
+            boolean local;
+            if (isNotBlank(localDrpcString)) {
+                local = Boolean.parseBoolean(localDrpcString);
+            } else {
+                local = stormConf.get(Config.STORM_CLUSTER_MODE).equals("local");
+            }
+            if (local) {
+                _factory = new LocalDRPCInvocationFactory();
+            } else {
+                _factory = new DRPCInvocationsClientFactory();
+            }
+        }
     }
 
     @Override
     public void execute(Tuple input) {
         String result = (String) input.getValue(0);
         String returnInfo = (String) input.getValue(1);
-        if(returnInfo!=null) {
+        if (returnInfo != null) {
             Map retMap = (Map) JSONValue.parse(returnInfo);
             final String host = (String) retMap.get("host");
             final int port = Utils.getInt(retMap.get("port"));
             String id = (String) retMap.get("id");
-            DistributedRPCInvocations.Iface client;
-            if(local) {
-                client = (DistributedRPCInvocations.Iface) ServiceRegistry.getService(host);
-            } else {
-                List server = new ArrayList() {{
-                    add(host);
-                    add(port);
-                }};
-            
-                if(!_clients.containsKey(server)) {
-                    _clients.put(server, new DRPCInvocationsClient(host, port));
-                }
-                client = _clients.get(server);
+            DRPCInvocations client;
+            HostAndPort server = HostAndPort.fromParts(host, port);
+
+            if (!_clients.containsKey(server)) {
+                _clients.put(server, _factory.getClientForServer(server));
             }
-                
+            client = _clients.get(server);
+
             try {
                 client.result(id, result);
                 _collector.ack(input);
-            } catch(TException e) {
+            } catch (TException e) {
                 LOG.error("Failed to return results to DRPC server", e);
                 _collector.fail(input);
             }
         }
-    }    
+    }
 
     @Override
     public void cleanup() {
-        for(DRPCInvocationsClient c: _clients.values()) {
+        for (DRPCInvocations c : _clients.values()) {
             c.close();
         }
     }

--- a/storm-core/src/jvm/backtype/storm/drpc/ReturnResults.java
+++ b/storm-core/src/jvm/backtype/storm/drpc/ReturnResults.java
@@ -1,6 +1,5 @@
 package backtype.storm.drpc;
 
-import backtype.storm.Config;
 import backtype.storm.task.OutputCollector;
 import backtype.storm.task.TopologyContext;
 import backtype.storm.topology.OutputFieldsDeclarer;
@@ -15,8 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 
 public class ReturnResults extends BaseRichBolt {
@@ -38,21 +35,6 @@ public class ReturnResults extends BaseRichBolt {
     @Override
     public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
         _collector = collector;
-        // Yuck.  Would happily ditch this if backwards compatibility is not an issue.
-        if (_factory == null) {
-            String localDrpcString = (String) stormConf.get(Config.STORM_CLUSTER_DRPC_IS_LOCAL);
-            boolean local;
-            if (isNotBlank(localDrpcString)) {
-                local = Boolean.parseBoolean(localDrpcString);
-            } else {
-                local = stormConf.get(Config.STORM_CLUSTER_MODE).equals("local");
-            }
-            if (local) {
-                _factory = new LocalDRPCInvocationFactory();
-            } else {
-                _factory = new DRPCInvocationsClientFactory();
-            }
-        }
     }
 
     @Override

--- a/storm-core/src/jvm/backtype/storm/utils/DRPCClient.java
+++ b/storm-core/src/jvm/backtype/storm/utils/DRPCClient.java
@@ -9,59 +9,81 @@ import org.apache.thrift7.transport.TSocket;
 import org.apache.thrift7.transport.TTransport;
 
 public class DRPCClient implements DistributedRPC.Iface {
-    private TTransport conn;
-    private DistributedRPC.Client client;
-    private String host;
-    private int port;
-    private Integer timeout;
+    protected TTransport conn;
+    protected DistributedRPC.Client client;
+    protected String host;
+    protected int port;
+    protected Integer timeout;
 
-    public DRPCClient(String host, int port, Integer timeout) {
+    public DRPCClient(String host, int port, Integer timeout, boolean connectImmediately) {
         try {
             this.host = host;
             this.port = port;
             this.timeout = timeout;
-            connect();
-        } catch(TException e) {
+            if (connectImmediately)
+                connect();
+        } catch (TException e) {
             throw new RuntimeException(e);
         }
     }
-    
+
+    public DRPCClient(String host, int port, Integer timeout) {
+        this(host, port, timeout, true);
+    }
+
     public DRPCClient(String host, int port) {
         this(host, port, null);
     }
-    
-    private void connect() throws TException {
+
+    protected void ensureConnected() throws TException {
+        if (!isConnected())
+            connect();
+    }
+
+    protected boolean isConnected() {
+        return conn != null && conn.isOpen();
+    }
+
+    protected void connect() throws TException {
         TSocket socket = new TSocket(host, port);
-        if(timeout!=null) {
+        if (timeout != null) {
             socket.setTimeout(timeout);
         }
         conn = new TFramedTransport(socket);
         client = new DistributedRPC.Client(new TBinaryProtocol(conn));
         conn.open();
     }
-    
+
     public String getHost() {
         return host;
     }
-    
+
     public int getPort() {
         return port;
-    }   
-    
+    }
+
     public String execute(String func, String args) throws TException, DRPCExecutionException {
         try {
-            if(client==null) connect();
-            return client.execute(func, args);
-        } catch(TException e) {
-            client = null;
+            return doExecute(func, args);
+        } catch (TException e) {
+            close();
             throw e;
-        } catch(DRPCExecutionException e) {
-            client = null;
+        } catch (DRPCExecutionException e) {
+            close();
             throw e;
         }
     }
 
+    protected String doExecute(String func, String args) throws TException, DRPCExecutionException {
+        ensureConnected();
+        return client.execute(func, args);
+    }
+
     public void close() {
-        conn.close();
+        if (conn != null) {
+            conn.close();
+            conn = null;
+        }
+        client = null;
     }
 }

--- a/storm-core/src/jvm/backtype/storm/utils/FixedSizeDRPCClientPool.java
+++ b/storm-core/src/jvm/backtype/storm/utils/FixedSizeDRPCClientPool.java
@@ -1,0 +1,87 @@
+package backtype.storm.utils;
+
+import backtype.storm.drpc.AbstractFixedSizePool;
+import backtype.storm.generated.DRPCExecutionException;
+import backtype.storm.generated.DistributedRPC;
+import com.google.common.net.HostAndPort;
+import org.apache.thrift7.TException;
+import org.apache.thrift7.transport.TTransportException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class FixedSizeDRPCClientPool extends AbstractFixedSizePool<FixedSizeDRPCClientPool.RetryConnectionOnceDRPCClient> implements DistributedRPC.Iface {
+
+    public static Logger LOG = LoggerFactory.getLogger(FixedSizeDRPCClientPool.class);
+
+    public FixedSizeDRPCClientPool(List<HostAndPort> hosts, int connectionsPerHost, int timeout, boolean connectImmediately) {
+        super(connectionsPerHost * hosts.size());
+        List<RetryConnectionOnceDRPCClient> clients = new ArrayList<RetryConnectionOnceDRPCClient>(connectionsPerHost * hosts.size());
+        for (HostAndPort host : hosts) {
+            for (int i = 0; i < connectionsPerHost; ++i)
+                clients.add(createClient(timeout, connectImmediately, host));
+        }
+        // Shuffle clients so load is "uniformly" distributed
+        Collections.shuffle(clients);
+        queue.addAll(clients);
+    }
+
+    private RetryConnectionOnceDRPCClient createClient(int timeout, boolean connectImmediately, HostAndPort host) {
+        RetryConnectionOnceDRPCClient client = new RetryConnectionOnceDRPCClient(host.getHostText(), host.getPort(), timeout, false);
+        // We don't want the DRPC client's being unavailable to stop client startup, so connect in a separate step.
+        if (connectImmediately) {
+            try {
+                client.ensureConnected();
+            } catch (TException e) {
+                LOG.warn("Unable to eagerly connect to {}, leaving in unconnected state: ", host, e);
+                client.close();
+            }
+        }
+        return client;
+
+    }
+
+    @Override
+    public String execute(String functionName, String funcArgs) throws DRPCExecutionException, TException {
+        RetryConnectionOnceDRPCClient client = take();
+        try {
+            return client.execute(functionName, funcArgs);
+        } finally {
+            put(client);
+        }
+    }
+
+    public String execute(String functionName, String funcArgs, int timeout, TimeUnit timeUnit) throws DRPCExecutionException, TException {
+        RetryConnectionOnceDRPCClient client = take(timeout, timeUnit);
+        if (client == null)
+            return null;
+        try {
+            return client.execute(functionName, funcArgs);
+        } finally {
+            put(client);
+        }
+    }
+
+    public static class RetryConnectionOnceDRPCClient extends DRPCClient {
+
+        public RetryConnectionOnceDRPCClient(String host, int port, Integer timeout, boolean connectImmediately) {
+            super(host, port, timeout, connectImmediately);
+        }
+
+        @Override
+        public String doExecute(String func, String args) throws TException, DRPCExecutionException {
+            try {
+                return super.doExecute(func, args);
+            } catch (TTransportException e) {
+                // We'll catch the first transport-related connection (timeout, reconnect, whatever) and retry
+                LOG.debug("Caught transport exception during execution; reconnecting and re-trying: ", e);
+                close();
+                return super.doExecute(func, args);
+            }
+        }
+    }
+}

--- a/storm-core/src/jvm/storm/trident/TridentTopology.java
+++ b/storm-core/src/jvm/storm/trident/TridentTopology.java
@@ -3,6 +3,7 @@ package storm.trident;
 import backtype.storm.Config;
 import backtype.storm.ILocalDRPC;
 import backtype.storm.drpc.DRPCSpout;
+import backtype.storm.drpc.LocalDRPCInvocationFactory;
 import backtype.storm.generated.GlobalStreamId;
 import backtype.storm.generated.Grouping;
 import backtype.storm.generated.StormTopology;
@@ -11,15 +12,6 @@ import backtype.storm.topology.BoltDeclarer;
 import backtype.storm.topology.IRichSpout;
 import backtype.storm.tuple.Fields;
 import backtype.storm.utils.Utils;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeMap;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.UndirectedGraph;
 import org.jgrapht.alg.ConnectivityInspector;
@@ -33,34 +25,20 @@ import storm.trident.graph.GraphGrouper;
 import storm.trident.graph.Group;
 import storm.trident.operation.GroupedMultiReducer;
 import storm.trident.operation.MultiReducer;
-import storm.trident.operation.impl.FilterExecutor;
-import storm.trident.operation.impl.GroupedMultiReducerExecutor;
-import storm.trident.operation.impl.IdentityMultiReducer;
-import storm.trident.operation.impl.JoinerMultiReducer;
-import storm.trident.operation.impl.TrueFilter;
+import storm.trident.operation.impl.*;
 import storm.trident.partition.IdentityGrouping;
-import storm.trident.planner.Node;
-import storm.trident.planner.NodeStateInfo;
-import storm.trident.planner.PartitionNode;
-import storm.trident.planner.ProcessorNode;
-import storm.trident.planner.SpoutNode;
-import storm.trident.planner.SubtopologyBolt;
+import storm.trident.planner.*;
 import storm.trident.planner.processor.EachProcessor;
 import storm.trident.planner.processor.MultiReducerProcessor;
-import storm.trident.spout.BatchSpoutExecutor;
-import storm.trident.spout.IBatchSpout;
-import storm.trident.spout.IOpaquePartitionedTridentSpout;
-import storm.trident.spout.IPartitionedTridentSpout;
-import storm.trident.spout.ITridentSpout;
-import storm.trident.spout.OpaquePartitionedTridentSpoutExecutor;
-import storm.trident.spout.PartitionedTridentSpoutExecutor;
-import storm.trident.spout.RichSpoutBatchExecutor;
+import storm.trident.spout.*;
 import storm.trident.state.StateFactory;
 import storm.trident.state.StateSpec;
 import storm.trident.topology.TridentTopologyBuilder;
 import storm.trident.util.ErrorEdgeFactory;
 import storm.trident.util.IndexedEdge;
 import storm.trident.util.TridentUtils;
+
+import java.util.*;
 
 
 // graph with 3 kinds of nodes:
@@ -124,7 +102,7 @@ public class TridentTopology {
         if(server==null) {
             spout = new DRPCSpout(function);
         } else {
-            spout = new DRPCSpout(function, server);
+            spout = new DRPCSpout(function, new LocalDRPCInvocationFactory(server));
         }
         return newDRPCStream(spout);
     }

--- a/storm-core/src/jvm/storm/trident/drpc/ReturnResultsReducer.java
+++ b/storm-core/src/jvm/storm/trident/drpc/ReturnResultsReducer.java
@@ -1,10 +1,7 @@
 package storm.trident.drpc;
 
-import backtype.storm.Config;
 import backtype.storm.drpc.DRPCInvocations;
-import backtype.storm.drpc.DRPCInvocationsClientFactory;
 import backtype.storm.drpc.DRPCInvocationsFactory;
-import backtype.storm.drpc.LocalDRPCInvocationFactory;
 import backtype.storm.utils.Utils;
 import com.google.common.net.HostAndPort;
 import org.apache.commons.lang.builder.ToStringBuilder;
@@ -20,8 +17,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 
 public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
@@ -47,21 +42,6 @@ public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
 
     @Override
     public void prepare(Map stormConf, TridentMultiReducerContext context) {
-        // Yuck.  Would happily ditch this if backwards compatibility is not an issue.
-        if (_factory == null) {
-            String localDrpcString = (String) stormConf.get(Config.STORM_CLUSTER_DRPC_IS_LOCAL);
-            boolean local;
-            if (isNotBlank(localDrpcString)) {
-                local = Boolean.parseBoolean(localDrpcString);
-            } else {
-                local = stormConf.get(Config.STORM_CLUSTER_MODE).equals("local");
-            }
-            if (local) {
-                _factory = new LocalDRPCInvocationFactory();
-            } else {
-                _factory = new DRPCInvocationsClientFactory();
-            }
-        }
     }
 
     @Override

--- a/storm-core/src/jvm/storm/trident/drpc/ReturnResultsReducer.java
+++ b/storm-core/src/jvm/storm/trident/drpc/ReturnResultsReducer.java
@@ -1,14 +1,12 @@
 package storm.trident.drpc;
 
 import backtype.storm.Config;
-import backtype.storm.drpc.DRPCInvocationsClient;
-import backtype.storm.generated.DistributedRPCInvocations;
-import backtype.storm.utils.ServiceRegistry;
+import backtype.storm.drpc.DRPCInvocations;
+import backtype.storm.drpc.DRPCInvocationsClientFactory;
+import backtype.storm.drpc.DRPCInvocationsFactory;
+import backtype.storm.drpc.LocalDRPCInvocationFactory;
 import backtype.storm.utils.Utils;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.common.net.HostAndPort;
 import org.apache.commons.lang.builder.ToStringBuilder;
 import org.apache.thrift7.TException;
 import org.json.simple.JSONValue;
@@ -17,6 +15,13 @@ import storm.trident.operation.MultiReducer;
 import storm.trident.operation.TridentCollector;
 import storm.trident.operation.TridentMultiReducerContext;
 import storm.trident.tuple.TridentTuple;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 
 public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
@@ -29,14 +34,34 @@ public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
             return ToStringBuilder.reflectionToString(this);
         }
     }
-    boolean local;
 
-    Map<List, DRPCInvocationsClient> _clients = new HashMap<List, DRPCInvocationsClient>();
-    
-    
+    protected DRPCInvocationsFactory _factory;
+    Map<HostAndPort, DRPCInvocations> _clients = new HashMap<HostAndPort, DRPCInvocations>();
+
+    public ReturnResultsReducer() {
+    }
+
+    public ReturnResultsReducer(DRPCInvocationsFactory factory) {
+        this._factory = factory;
+    }
+
     @Override
-    public void prepare(Map conf, TridentMultiReducerContext context) {
-        local = conf.get(Config.STORM_CLUSTER_MODE).equals("local");
+    public void prepare(Map stormConf, TridentMultiReducerContext context) {
+        // Yuck.  Would happily ditch this if backwards compatibility is not an issue.
+        if (_factory == null) {
+            String localDrpcString = (String) stormConf.get(Config.STORM_CLUSTER_DRPC_IS_LOCAL);
+            boolean local;
+            if (isNotBlank(localDrpcString)) {
+                local = Boolean.parseBoolean(localDrpcString);
+            } else {
+                local = stormConf.get(Config.STORM_CLUSTER_MODE).equals("local");
+            }
+            if (local) {
+                _factory = new LocalDRPCInvocationFactory();
+            } else {
+                _factory = new DRPCInvocationsClientFactory();
+            }
+        }
     }
 
     @Override
@@ -46,7 +71,7 @@ public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
 
     @Override
     public void execute(ReturnResultsState state, int streamIndex, TridentTuple input, TridentCollector collector) {
-        if(streamIndex==0) {
+        if (streamIndex == 0) {
             state.returnInfo = input.getString(0);
         } else {
             state.results.add(input);
@@ -56,30 +81,23 @@ public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
     @Override
     public void complete(ReturnResultsState state, TridentCollector collector) {
         // only one of the multireducers will receive the tuples
-        if(state.returnInfo!=null) {
+        if (state.returnInfo != null) {
             String result = JSONValue.toJSONString(state.results);
             Map retMap = (Map) JSONValue.parse(state.returnInfo);
             final String host = (String) retMap.get("host");
             final int port = Utils.getInt(retMap.get("port"));
             String id = (String) retMap.get("id");
-            DistributedRPCInvocations.Iface client;
-            if(local) {
-                client = (DistributedRPCInvocations.Iface) ServiceRegistry.getService(host);
-            } else {
-                List server = new ArrayList() {{
-                    add(host);
-                    add(port);
-                }};
+            DRPCInvocations client;
+            HostAndPort server = HostAndPort.fromParts(host, port);
 
-                if(!_clients.containsKey(server)) {
-                    _clients.put(server, new DRPCInvocationsClient(host, port));
-                }
-                client = _clients.get(server);
+            if (!_clients.containsKey(server)) {
+                _clients.put(server, _factory.getClientForServer(server));
             }
+            client = _clients.get(server);
 
             try {
                 client.result(id, result);
-            } catch(TException e) {
+            } catch (TException e) {
                 collector.reportError(e);
             }
         }
@@ -87,9 +105,9 @@ public class ReturnResultsReducer implements MultiReducer<ReturnResultsState> {
 
     @Override
     public void cleanup() {
-        for(DRPCInvocationsClient c: _clients.values()) {
+        for (DRPCInvocations c : _clients.values()) {
             c.close();
         }
     }
-    
+
 }


### PR DESCRIPTION
add straightforward fixed-size pooling for DRPCClients and DRPCInvocationClients.nClients.

refactor DRPCSpout and ReturnResults to take factories which allows pooling.

Clean up LocalDRPC hokyness with factories which we use for pooling anyway.
