### PR TITLE
Specify jvm_opts when calling storm jar

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -29,6 +29,9 @@ if (not os.path.isfile(USER_CONF_DIR + "/storm.yaml")):
     USER_CONF_DIR = CLUSTER_CONF_DIR
 CONFIG_OPTS = []
 CONFFILE = ""
+JAR_JVM_OPTS = os.getenv('STORM_JAR_JVM_OPTS', '')
+
+print "Jvm opts" + JAR_JVM_OPTS
 
 
 def get_config_opts():
@@ -138,7 +141,7 @@ def jar(jarfile, klass, *args):
         jvmtype="-client",
         extrajars=[jarfile, USER_CONF_DIR, STORM_DIR + "/bin"],
         args=args,
-        jvmopts=["-Dstorm.jar=" + jarfile])
+        jvmopts=[JAR_JVM_OPTS + " -Dstorm.jar=" + jarfile])
 
 def kill(*args):
     """Syntax: [storm kill topology-name [-w wait-time-secs]]

--- a/bin/storm
+++ b/bin/storm
@@ -31,8 +31,6 @@ CONFIG_OPTS = []
 CONFFILE = ""
 JAR_JVM_OPTS = os.getenv('STORM_JAR_JVM_OPTS', '')
 
-print "Jvm opts" + JAR_JVM_OPTS
-
 
 def get_config_opts():
     global CONFIG_OPTS


### PR DESCRIPTION
This is a simple change to allow calling bin/storm jar with options that are passed from the command line.  We have a local change for this that we're using in house to deploy topology's to jenkins and having this in a release of storm would be great.
