### PR TITLE
Add support for ShellBolt and ShellProcess objects to accept custom environment variables.

### DIFF
--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -8,6 +8,7 @@ import backtype.storm.utils.ShellProcess;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -60,6 +61,7 @@ public class ShellBolt implements IBolt {
     
     private Thread _readerThread;
     private Thread _writerThread;
+    private HashMap<String, String> _environment;
 
     public ShellBolt(ShellComponent component) {
         this(component.get_execution_command(), component.get_script());
@@ -67,12 +69,21 @@ public class ShellBolt implements IBolt {
 
     public ShellBolt(String... command) {
         _command = command;
+        _environment = new HashMap<String, String>();
+    }
+
+    public void setEnvironmentVariable(String key, String value) {
+        _environment.put(key, value);
+    }
+
+    public Map<String, String> getEnvironment() {
+        return _environment;
     }
 
     public void prepare(Map stormConf, TopologyContext context,
                         final OutputCollector collector) {
         _rand = new Random();
-        _process = new ShellProcess(_command);
+        _process = new ShellProcess(_command, _environment);
         _collector = collector;
 
         try {

--- a/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
 
@@ -22,14 +23,24 @@ public class ShellProcess {
     private InputStream processErrorStream;
     private Process _subprocess;
     private String[] command;
+    private Map<String, String> environment;
 
     public ShellProcess(String[] command) {
+        this(command, null);
+    }
+
+    public ShellProcess(String[] command, Map<String, String> environment) {
         this.command = command;
+        if (environment == null) {
+            environment = new HashMap<String, String>();
+        }
+        this.environment = environment;
     }
 
     public Number launch(Map conf, TopologyContext context) throws IOException {
         ProcessBuilder builder = new ProcessBuilder(command);
         builder.directory(new File(context.getCodeDir()));
+        builder.environment().putAll(environment);
         _subprocess = builder.start();
 
         processIn = new DataOutputStream(_subprocess.getOutputStream());


### PR DESCRIPTION
We have a custom environment that needs this support.  This was brought up a couple of years ago.  It seems that writing a bash script wrapper is overhead that storm would want to avoid.

https://github.com/nathanmarz/storm/issues/32
