### PR TITLE
remove storm-*.jar from lib dir

### DIFF
--- a/bin/build_release.sh
+++ b/bin/build_release.sh
@@ -47,7 +47,12 @@ cp -R bin $DIR/
 cp README.markdown $DIR/
 cp LICENSE.html $DIR/
 
-cd _release
+cd _release/storm-$RELEASE
+for i in *.jar
+do
+	rm -f ./lib/$i
+done
+cd ..
 zip -r storm-$RELEASE.zip *
 cd ..
 mv _release/storm-*.zip .


### PR DESCRIPTION
storm-0.9.0.wip19.jar is copied to lib dir as a dependency of other modules. So storm can not startup due to multiple conf file in classpath. Just delete duplicated top jar files in lib dir.
