### PR TITLE
Launch workers with id and port properties

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -418,6 +418,9 @@
                        " -Dlogfile.name=" logfilename
                        " -Dstorm.home=" storm-home
                        " -Dlogback.configurationFile=" storm-home "/logback/cluster.xml"
+                       " -Dstorm.id=" storm-id
+                       " -Dworker.id=" worker-id
+                       " -Dworker.port=" port
                        " -cp " classpath " backtype.storm.daemon.worker "
                        (java.net.URLEncoder/encode storm-id) " " (:assignment-id supervisor)
                        " " port " " worker-id)]


### PR DESCRIPTION
Launch workers with id and port properties

When logging to a central location with a logging utility like syslog,
make it possible to split logs using logging configuration.

This greatly helps, e.g., when viewing logs when many different large
topologies running concurrently.
