### PR TITLE
Fixes to build_release.sh script

### DIFF
--- a/bin/build_modules.sh
+++ b/bin/build_modules.sh
@@ -1,25 +1,32 @@
 #!/bin/bash
 
-LEIN=`which lein2 || which lein` 
+set -e  # die if anything bad happens
+
+function banner {
+  echo ; echo "------------- $1 ---------------" ; echo
+}
+
+LEIN=`which lein2 || which lein`
 export LEIN_ROOT=1
 
 
 for module in $(cat MODULES)
 do
-	echo "Building $module"
-	cd $module
-	if [ $module != "storm-console-logging" ]
-		then
-			rm ../conf/logback.xml
-	fi
+  banner "Building $module"
+  cd $module
+  if [ $module != "storm-console-logging" ]
+  then
+    rm -f ../conf/logback.xml
+  else
+    git checkout ../conf/logback.xml ; true
+  fi
 
+  $LEIN with-profile release clean
+  $LEIN with-profile release deps
+  $LEIN with-profile release jar
+  $LEIN with-profile release install
+  $LEIN with-profile release pom
 
-	$LEIN with-profile release clean
-	$LEIN with-profile release deps
-	$LEIN with-profile release jar
-	$LEIN with-profile release install
-	$LEIN with-profile release pom
-
-	git checkout ../conf/logback.xml
-	cd ..
+  git checkout ../conf/logback.xml ; true
+  cd ..
 done

--- a/bin/storm
+++ b/bin/storm
@@ -39,6 +39,7 @@ if not os.path.exists(STORM_DIR + "/RELEASE"):
     print "******************************************"
     print "The storm client can only be run from within a release. You appear to be trying to run the client from a checkout of Storm's source code."
     print "\nYou can download a Storm release at https://github.com/nathanmarz/storm/downloads"
+    print "\nor build it yourself by running ./bin/build_release.sh from a clone of the source repo."
     print "******************************************"
     sys.exit(1)  
 

--- a/storm-console-logging/project.clj
+++ b/storm-console-logging/project.clj
@@ -2,6 +2,8 @@
 (def VERSION (-> ROOT-DIR (str "/../VERSION") slurp (.trim)))
 
 (defproject storm/storm-console-logging VERSION
+  :dependencies [[org.clojure/clojure "1.4.0"]
+                ]
   :resource-paths ["logback"]
 
   :profiles {:release {}

--- a/storm-console-logging/project.clj
+++ b/storm-console-logging/project.clj
@@ -6,7 +6,7 @@
                 ]
   :resource-paths ["logback"]
 
-  :profiles {:release {}
+  :profiles {
+             :release { :target-path "target" }
              }
-
   :aot :all)

--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -36,7 +36,7 @@
 
   :profiles {:dev {:resource-paths ["src/dev"]
                    :dependencies [[org.mockito/mockito-all "1.9.5"]]}
-             :release {}
+             :release { :target-path "target" }
              :lib {}
              }
 

--- a/storm-netty/project.clj
+++ b/storm-netty/project.clj
@@ -6,6 +6,8 @@
                  [io.netty/netty "3.6.3.Final"]]
   :java-source-paths ["src/jvm"]
   :test-paths ["test/clj"]
-  :profiles {:release {}}
+  :profiles {
+             :release { :target-path "target" }
+	     }
   :jvm-opts ["-Djava.library.path=/usr/local/lib:/opt/local/lib:/usr/lib"]
   :aot :all))


### PR DESCRIPTION
- maven is putting the `storm-*` jar files in target/release+provided, not target/provided. Fixed path.
- storm-netty had a dependency itself on storm-core, so the storm-core jar was in both _release and _release/lib. Removing the dupe jar from `lib/`
- storm-console-processor was letting clojure-1.2 meet its dependency list, making for two clojure jars in the tarball. Added a dependency to its `project.clj`.
- build_releases.sh should fail if the build_modules.sh script fails. Made build_modules.sh run with set -e, and made build_releases.sh fail if it does
- made pretty banners, made paths be properly quoted
- bin/ directory files copy with permissions intact. Also now remove build_release.sh and build_modules.sh, since they won't work
- rather than remove _release and *.zip, only removes the specific subdirectory and .zip file. If you run with `STORM_KEEP_RELEASE=true`, it will not delete the release dir at the end of script (only at beginning)
