### PR TITLE
install_zmq.sh cleans up after itself

### DIFF
--- a/bin/install_zmq.sh
+++ b/bin/install_zmq.sh
@@ -13,8 +13,8 @@ Looks like you're missing your 'include' directory. If you're using Mac OS X, Yo
 fi
 
 #install zeromq
-wget http://download.zeromq.org/zeromq-2.1.7.tar.gz
-tar -xzf zeromq-2.1.7.tar.gz
+wget -c http://download.zeromq.org/zeromq-2.1.7.tar.gz
+tar -xzf zeromq-2.1.7.tar.gz && rm -f zeromq-2.1.7.tar.gz
 cd zeromq-2.1.7
 ./configure
 make


### PR DESCRIPTION
wget -c makes sure that the file is written as zeromq-2.1.7.tar.gz, not zeromq-2.1.7.tar.gz.1, zeromq-2.1.7.tar.gz.2, ...

On success of untarring (&&), the archive is removed
