### PR TITLE
Passing configs from storm.yaml to TopologyValidator

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -907,7 +907,8 @@
           (.validate ^backtype.storm.nimbus.ITopologyValidator (:validator nimbus)
                      storm-name
                      (from-json serializedConf)
-                     topology)
+                     topology
+                     conf)
           (swap! (:submitted-count nimbus) inc)
           (let [storm-id (str storm-name "-" @(:submitted-count nimbus) "-" (current-time-secs))
                 storm-conf (normalize-conf

--- a/storm-core/src/jvm/backtype/storm/nimbus/DefaultTopologyValidator.java
+++ b/storm-core/src/jvm/backtype/storm/nimbus/DefaultTopologyValidator.java
@@ -6,6 +6,6 @@ import java.util.Map;
 
 public class DefaultTopologyValidator implements ITopologyValidator {
     @Override
-    public void validate(String topologyName, Map topologyConf, StormTopology topology) throws InvalidTopologyException {        
+    public void validate(String topologyName, Map topologyConf, StormTopology topology, Map NimbusConf) throws InvalidTopologyException {        
     }    
 }

--- a/storm-core/src/jvm/backtype/storm/nimbus/ITopologyValidator.java
+++ b/storm-core/src/jvm/backtype/storm/nimbus/ITopologyValidator.java
@@ -5,6 +5,6 @@ import backtype.storm.generated.StormTopology;
 import java.util.Map;
 
 public interface ITopologyValidator {
-    void validate(String topologyName, Map topologyConf, StormTopology topology)
+    void validate(String topologyName, Map topologyConf, StormTopology topology, Map NimbusConf)
             throws InvalidTopologyException;
 }

--- a/storm-core/src/jvm/backtype/storm/nimbus/ITopologyValidator.java
+++ b/storm-core/src/jvm/backtype/storm/nimbus/ITopologyValidator.java
@@ -5,6 +5,7 @@ import backtype.storm.generated.StormTopology;
 import java.util.Map;
 
 public interface ITopologyValidator {
+    void prepare(String topologyName, Map topologyConf, StormTopology topology, Map NimbusConf);
     void validate(String topologyName, Map topologyConf, StormTopology topology, Map NimbusConf)
             throws InvalidTopologyException;
 }


### PR DESCRIPTION
Passing contents of storm.yaml to TopologyValidator so that we can add more hooks in topology validator. For example with this change we can say that only allow those topologies to be pushed which are part of the isolation scheduler map in yaml file.

Thanks,
Ankit.
