### PR TITLE
enable nimbus & UI servers to be asisgned with available port, instead of pre-configured 

### DIFF
--- a/storm-core/src/clj/backtype/storm/bootstrap.clj
+++ b/storm-core/src/clj/backtype/storm/bootstrap.clj
@@ -39,7 +39,7 @@
                      KillOptions SubmitOptions RebalanceOptions JavaObject JavaObjectArg
                      TopologyInitialStatus]))
      (import (quote [backtype.storm.daemon.common StormBase Assignment
-                     SupervisorInfo WorkerHeartbeat]))
+                     SupervisorInfo WorkerHeartbeat HostPort]))
      (import (quote [backtype.storm.grouping CustomStreamGrouping]))
      (import (quote [java.io File FileOutputStream FileInputStream]))
      (import (quote [java.util Collection List Random Map HashMap Collections ArrayList LinkedList]))

--- a/storm-core/src/clj/backtype/storm/bootstrap.clj
+++ b/storm-core/src/clj/backtype/storm/bootstrap.clj
@@ -39,8 +39,9 @@
                      KillOptions SubmitOptions RebalanceOptions JavaObject JavaObjectArg
                      TopologyInitialStatus]))
      (import (quote [backtype.storm.daemon.common StormBase Assignment
-                     SupervisorInfo WorkerHeartbeat HostPort]))
+                     SupervisorInfo WorkerHeartbeat]))
      (import (quote [backtype.storm.grouping CustomStreamGrouping]))
+     (import (quote [backtype.storm.utils HostPort]))
      (import (quote [java.io File FileOutputStream FileInputStream]))
      (import (quote [java.util Collection List Random Map HashMap Collections ArrayList LinkedList]))
      (import (quote [org.apache.commons.io FileUtils]))

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -119,14 +119,17 @@
   (remove-storm! [this storm-id])
   (report-error [this storm-id task-id error])
   (errors [this storm-id task-id])
-  (nimbus-info [this])  ;; fetch nimbus host + port as NimbusHostPort record
+  (nimbus-info [this])  ;; fetch nimbus host + port as HostPort
   (set-nimbus!  [this info])  ;; announce nimbus host+port
+  (ui-port [this])  ;; fetch ui port as Integer
+  (set-ui-port!  [this info])  ;; announce ui port
 
   (disconnect [this])
   )
 
 
 (def NIMBUS-ROOT "nimbus")
+(def UI-ROOT "ui")
 (def ASSIGNMENTS-ROOT "assignments")
 (def CODE-ROOT "code")
 (def STORMS-ROOT "storms")
@@ -135,6 +138,7 @@
 (def ERRORS-ROOT "errors")
 
 (def NIMBUS-SUBTREE (str "/" NIMBUS-ROOT))
+(def UI-SUBTREE (str "/" UI-ROOT))
 (def ASSIGNMENTS-SUBTREE (str "/" ASSIGNMENTS-ROOT))
 (def STORMS-SUBTREE (str "/" STORMS-ROOT))
 (def SUPERVISORS-SUBTREE (str "/" SUPERVISORS-ROOT))
@@ -230,6 +234,12 @@
      
      (set-nimbus! [this info]
        (set-data cluster-state NIMBUS-SUBTREE (Utils/serialize info)))
+
+     (ui-port [this]
+       (maybe-deserialize (get-data cluster-state UI-SUBTREE false)))
+     
+     (set-ui-port! [this info]
+       (set-data cluster-state UI-SUBTREE (Utils/serialize info)))
 
      (assignments [this callback]
         (when callback

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -5,7 +5,6 @@
   (:use [backtype.storm util log config])
   (:require [backtype.storm [zookeeper :as zk]])
   (:require [backtype.storm.daemon [common :as common]])
-  
   )
 
 (defprotocol ClusterState

--- a/storm-core/src/clj/backtype/storm/cluster.clj
+++ b/storm-core/src/clj/backtype/storm/cluster.clj
@@ -120,11 +120,14 @@
   (remove-storm! [this storm-id])
   (report-error [this storm-id task-id error])
   (errors [this storm-id task-id])
+  (nimbus-info [this])  ;; fetch nimbus host + port as NimbusHostPort record
+  (set-nimbus!  [this info])  ;; announce nimbus host+port
 
   (disconnect [this])
   )
 
 
+(def NIMBUS-ROOT "nimbus")
 (def ASSIGNMENTS-ROOT "assignments")
 (def CODE-ROOT "code")
 (def STORMS-ROOT "storms")
@@ -132,6 +135,7 @@
 (def WORKERBEATS-ROOT "workerbeats")
 (def ERRORS-ROOT "errors")
 
+(def NIMBUS-SUBTREE (str "/" NIMBUS-ROOT))
 (def ASSIGNMENTS-SUBTREE (str "/" ASSIGNMENTS-ROOT))
 (def STORMS-SUBTREE (str "/" STORMS-ROOT))
 (def SUPERVISORS-SUBTREE (str "/" SUPERVISORS-ROOT))
@@ -222,6 +226,12 @@
     (reify
      StormClusterState
      
+     (nimbus-info [this]
+       (maybe-deserialize (get-data cluster-state NIMBUS-SUBTREE false)))
+     
+     (set-nimbus! [this info]
+       (set-data cluster-state NIMBUS-SUBTREE (Utils/serialize info)))
+
      (assignments [this callback]
         (when callback
           (reset! assignments-callback callback))

--- a/storm-core/src/clj/backtype/storm/daemon/common.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/common.clj
@@ -1,6 +1,5 @@
 (ns backtype.storm.daemon.common
   (:use [backtype.storm log config util])
-  (:import [java.net ServerSocket])
   (:import [backtype.storm.generated StormTopology
             InvalidTopologyException GlobalStreamId])
   (:import [backtype.storm.utils Utils])
@@ -330,13 +329,4 @@
   (->> executor->node+port
        (mapcat (fn [[e node+port]] (for [t (executor-id->tasks e)] [t node+port])))
        (into {})))
-
-; allocate an available server port if port_in_conf<=0
-(defn assign-server-port [port]
-   (if (pos? port) port
-     (let [serverSocket (ServerSocket. 0)
-           port_assigned (.getLocalPort serverSocket)]
-       (.close serverSocket)
-       (log-message "Grabbed port number " port_assigned " instead of the configured port " port)
-       port_assigned)))
 

--- a/storm-core/src/clj/backtype/storm/daemon/common.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/common.clj
@@ -1,5 +1,6 @@
 (ns backtype.storm.daemon.common
   (:use [backtype.storm log config util])
+  (:import [java.net ServerSocket])
   (:import [backtype.storm.generated StormTopology
             InvalidTopologyException GlobalStreamId])
   (:import [backtype.storm.utils Utils])
@@ -47,7 +48,7 @@
 (def LS-LOCAL-ASSIGNMENTS "local-assignments")
 (def LS-APPROVED-WORKERS "approved-workers")
 
-
+(defrecord HostPort [host port])
 
 (defrecord WorkerHeartbeat [time-secs storm-id executors port])
 
@@ -331,3 +332,13 @@
   (->> executor->node+port
        (mapcat (fn [[e node+port]] (for [t (executor-id->tasks e)] [t node+port])))
        (into {})))
+
+; allocate an available server port if port_in_conf<=0
+(defn assign-server-port [port]
+   (if (pos? port) port
+     (let [serverSocket (ServerSocket. 0)
+           port_assigned (.getLocalPort serverSocket)]
+       (.close serverSocket)
+       (log-message "Grabbed port number " port_assigned " instead of the configured port " port)
+       port_assigned)))
+

--- a/storm-core/src/clj/backtype/storm/daemon/common.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/common.clj
@@ -48,8 +48,6 @@
 (def LS-LOCAL-ASSIGNMENTS "local-assignments")
 (def LS-APPROVED-WORKERS "approved-workers")
 
-(defrecord HostPort [host port])
-
 (defrecord WorkerHeartbeat [time-secs storm-id executors port])
 
 (defrecord ExecutorStats [^long processed

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -1135,7 +1135,7 @@
   (let [port_in_conf  (.intValue (Integer. (conf NIMBUS-THRIFT-PORT)))
         nimbus_port  (assign-server-port port_in_conf)]
     (assoc (assoc conf
-                  NIMBUS-THRIFT-PORT (.toString (Integer. nimbus_port))) 
+                  NIMBUS-THRIFT-PORT (Integer. nimbus_port)) 
            NIMBUS-HOST (.getCanonicalHostName (InetAddress/getLocalHost)))))
   
 (defn launch-server! [conf inimbus]

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -322,7 +322,7 @@
 (defserverfn mk-supervisor [conf shared-context ^ISupervisor isupervisor]
   (log-message "Starting Supervisor with conf " conf)
   (let [nimbusHostPort (.nimbus-info (cluster/mk-storm-cluster-state conf))
-        conf (assoc (assoc conf NIMBUS-HOST (:host nimbusHostPort)) NIMBUS-THRIFT-PORT (:port nimbusHostPort))]
+        conf (assoc (assoc conf NIMBUS-HOST (.host nimbusHostPort)) NIMBUS-THRIFT-PORT (.port nimbusHostPort))]
     (.prepare isupervisor conf (supervisor-isupervisor-dir conf))
     (FileUtils/cleanDirectory (File. (supervisor-tmp-dir conf)))
     (let [supervisor (supervisor-data conf shared-context isupervisor)

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -321,64 +321,66 @@
 ;; another thread launches events to restart any dead processes if necessary
 (defserverfn mk-supervisor [conf shared-context ^ISupervisor isupervisor]
   (log-message "Starting Supervisor with conf " conf)
-  (.prepare isupervisor conf (supervisor-isupervisor-dir conf))
-  (FileUtils/cleanDirectory (File. (supervisor-tmp-dir conf)))
-  (let [supervisor (supervisor-data conf shared-context isupervisor)
-        [event-manager processes-event-manager :as managers] [(event/event-manager false) (event/event-manager false)]                         
-        sync-processes (partial sync-processes supervisor)
-        synchronize-supervisor (mk-synchronize-supervisor supervisor sync-processes event-manager processes-event-manager)
-        heartbeat-fn (fn [] (.supervisor-heartbeat!
-                               (:storm-cluster-state supervisor)
-                               (:supervisor-id supervisor)
-                               (SupervisorInfo. (current-time-secs)
-                                                (:my-hostname supervisor)
-                                                (:assignment-id supervisor)
-                                                (keys @(:curr-assignment supervisor))
-                                                ;; used ports
-                                                (.getMetadata isupervisor)
+  (let [nimbusHostPort (.nimbus-info (cluster/mk-storm-cluster-state conf))
+        conf (assoc (assoc conf NIMBUS-HOST (:host nimbusHostPort)) NIMBUS-THRIFT-PORT (:port nimbusHostPort))]
+    (.prepare isupervisor conf (supervisor-isupervisor-dir conf))
+    (FileUtils/cleanDirectory (File. (supervisor-tmp-dir conf)))
+    (let [supervisor (supervisor-data conf shared-context isupervisor)
+          [event-manager processes-event-manager :as managers] [(event/event-manager false) (event/event-manager false)]                         
+          sync-processes (partial sync-processes supervisor)
+          synchronize-supervisor (mk-synchronize-supervisor supervisor sync-processes event-manager processes-event-manager)
+          heartbeat-fn (fn [] (.supervisor-heartbeat!
+                                (:storm-cluster-state supervisor)
+                                (:supervisor-id supervisor)
+                                (SupervisorInfo. (current-time-secs)
+                                                 (:my-hostname supervisor)
+                                                 (:assignment-id supervisor)
+                                                 (keys @(:curr-assignment supervisor))
+                                                 ;; used ports
+                                                 (.getMetadata isupervisor)
                                                 (conf SUPERVISOR-SCHEDULER-META)
                                                 ((:uptime supervisor)))))]
-    (heartbeat-fn)
-    ;; should synchronize supervisor so it doesn't launch anything after being down (optimization)
-    (schedule-recurring (:timer supervisor)
-                        0
-                        (conf SUPERVISOR-HEARTBEAT-FREQUENCY-SECS)
-                        heartbeat-fn)
-    (when (conf SUPERVISOR-ENABLE)
-      ;; This isn't strictly necessary, but it doesn't hurt and ensures that the machine stays up
-      ;; to date even if callbacks don't all work exactly right
-      (schedule-recurring (:timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor)))
+      (heartbeat-fn)
+      ;; should synchronize supervisor so it doesn't launch anything after being down (optimization)
       (schedule-recurring (:timer supervisor)
                           0
-                          (conf SUPERVISOR-MONITOR-FREQUENCY-SECS)
-                          (fn [] (.add processes-event-manager sync-processes))))
-    (log-message "Starting supervisor with id " (:supervisor-id supervisor) " at host " (:my-hostname supervisor))
-    (reify
-     Shutdownable
-     (shutdown [this]
-               (log-message "Shutting down supervisor " (:supervisor-id supervisor))
-               (reset! (:active supervisor) false)
+                          (conf SUPERVISOR-HEARTBEAT-FREQUENCY-SECS)
+                          heartbeat-fn)
+      (when (conf SUPERVISOR-ENABLE)
+        ;; This isn't strictly necessary, but it doesn't hurt and ensures that the machine stays up
+        ;; to date even if callbacks don't all work exactly right
+        (schedule-recurring (:timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor)))
+        (schedule-recurring (:timer supervisor)
+                            0
+                            (conf SUPERVISOR-MONITOR-FREQUENCY-SECS)
+                            (fn [] (.add processes-event-manager sync-processes))))
+      (log-message "Starting supervisor with id " (:supervisor-id supervisor) " at host " (:my-hostname supervisor))
+      (reify
+        Shutdownable
+        (shutdown [this]
+          (log-message "Shutting down supervisor " (:supervisor-id supervisor))
+          (reset! (:active supervisor) false)
                (cancel-timer (:timer supervisor))
                (.shutdown event-manager)
                (.shutdown processes-event-manager)
                (.disconnect (:storm-cluster-state supervisor)))
-     SupervisorDaemon
-     (get-conf [this]
-       conf)
-     (get-id [this]
-       (:supervisor-id supervisor))
-     (shutdown-all-workers [this]
-       (let [ids (my-worker-ids conf)]
-         (doseq [id ids]
-           (shutdown-worker supervisor id)
-           )))
-     DaemonCommon
-     (waiting? [this]
-       (or (not @(:active supervisor))
-           (and
-            (timer-waiting? (:timer supervisor))
-            (every? (memfn waiting?) managers)))
-           ))))
+        SupervisorDaemon
+        (get-conf [this]
+          conf)
+        (get-id [this]
+          (:supervisor-id supervisor))
+        (shutdown-all-workers [this]
+          (let [ids (my-worker-ids conf)]
+            (doseq [id ids]
+              (shutdown-worker supervisor id)
+              )))
+        DaemonCommon
+        (waiting? [this]
+          (or (not @(:active supervisor))
+              (and
+                (timer-waiting? (:timer supervisor))
+                (every? (memfn waiting?) managers)))
+          )))))
 
 (defn kill-supervisor [supervisor]
   (.shutdown supervisor)

--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -131,6 +131,7 @@
                            supervisors
                            (repeat supervisors {}))]
     (nimbus/announce-nimbus-info cluster-map (daemon-conf NIMBUS-HOST) (daemon-conf NIMBUS-THRIFT-PORT))
+    (ui/announce-ui-port daemon-conf)
     (doseq [sc supervisor-confs]
       (add-supervisor cluster-map :ports ports-per-supervisor :conf sc))
     cluster-map

--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -109,6 +109,7 @@
                            {STORM-CLUSTER-MODE "local"
                             STORM-ZOOKEEPER-PORT zk-port
                             STORM-ZOOKEEPER-SERVERS ["localhost"]})
+        daemon-conf (nimbus/config-with-nimbus-port-assigned daemon-conf)
         nimbus-tmp (local-temp-path)
         port-counter (mk-counter supervisor-slot-port-min)
         nimbus (nimbus/service-handler
@@ -127,6 +128,7 @@
         supervisor-confs (if (sequential? supervisors)
                            supervisors
                            (repeat supervisors {}))]
+    (nimbus/announce-nimbus-info cluster-map (daemon-conf NIMBUS-HOST) (daemon-conf NIMBUS-THRIFT-PORT))
     (doseq [sc supervisor-confs]
       (add-supervisor cluster-map :ports ports-per-supervisor :conf sc))
     cluster-map

--- a/storm-core/src/clj/backtype/storm/testing.clj
+++ b/storm-core/src/clj/backtype/storm/testing.clj
@@ -5,6 +5,7 @@
              [common :as common]
              [worker :as worker]
              [executor :as executor]])
+  (:require [backtype.storm.ui [core :as ui]])
   (:require [backtype.storm [process-simulator :as psim]])
   (:import [org.apache.commons.io FileUtils])
   (:import [java.io File])
@@ -110,6 +111,7 @@
                             STORM-ZOOKEEPER-PORT zk-port
                             STORM-ZOOKEEPER-SERVERS ["localhost"]})
         daemon-conf (nimbus/config-with-nimbus-port-assigned daemon-conf)
+        ui-conf (ui/config-with-ui-port-assigned daemon-conf)
         nimbus-tmp (local-temp-path)
         port-counter (mk-counter supervisor-slot-port-min)
         nimbus (nimbus/service-handler

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -21,6 +21,8 @@
   (:import [org.apache.commons.lang StringEscapeUtils])
   (:gen-class))
 
+(bootstrap)
+
 (defmacro with-nimbus [conf-sym nimbus-sym & body]
   `(let [state# (cluster/mk-storm-cluster-state ~conf-sym)
          hostPort# (.nimbus-info state#)] 

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -26,7 +26,7 @@
 (defmacro with-nimbus [conf-sym nimbus-sym & body]
   `(let [state# (cluster/mk-storm-cluster-state ~conf-sym)
          hostPort# (.nimbus-info state#)] 
-     (thrift/with-nimbus-connection [~nimbus-sym (:host hostPort#) (Integer. (:port hostPort#))]
+     (thrift/with-nimbus-connection [~nimbus-sym (.host hostPort#) (.port hostPort#)]
        ~@body
        )))
 

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -24,11 +24,9 @@
 (bootstrap)
 
 (defmacro with-nimbus [conf-sym nimbus-sym & body]
-  `(let [state# (cluster/mk-storm-cluster-state ~conf-sym)
-         hostPort# (.nimbus-info state#)] 
-     (thrift/with-nimbus-connection [~nimbus-sym (.host hostPort#) (.port hostPort#)]
-       ~@body
-       )))
+  `(thrift/with-nimbus-connection [~nimbus-sym (~conf-sym NIMBUS-HOST) (~conf-sym NIMBUS-THRIFT-PORT)]
+     ~@body
+     ))
 
 (defn get-filled-stats [summs]
   (->> summs

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -1,5 +1,5 @@
 (ns backtype.storm.util
-  (:import [java.net InetAddress])
+  (:import [java.net InetAddress ServerSocket])
   (:import [java.util Map Map$Entry List ArrayList Collection Iterator HashMap])
   (:import [java.io FileReader])
   (:import [backtype.storm Config])
@@ -833,3 +833,13 @@
                 (meta form))
               (list form x)))
   ([x form & more] `(-<> (-<> ~x ~form) ~@more)))
+
+; allocate an available server port if port_in_conf<=0
+(defn assign-server-port [port]
+   (if (pos? port) port
+     (let [serverSocket (ServerSocket. 0)
+           port_assigned (.getLocalPort serverSocket)]
+       (.close serverSocket)
+       (log-message "Grabbed port number " port_assigned " instead of the configured port " port)
+       port_assigned)))
+

--- a/storm-core/src/jvm/backtype/storm/utils/HostPort.java
+++ b/storm-core/src/jvm/backtype/storm/utils/HostPort.java
@@ -1,0 +1,26 @@
+package backtype.storm.utils;
+
+import java.io.Serializable;
+
+public class HostPort implements Serializable {
+    private static final long serialVersionUID = -4903345013121505849L;
+    String _host;
+    int _port;
+    
+    public HostPort(String host, int port) {
+        _host = host;
+        _port = port;
+    }
+    
+    public String host() {
+        return _host;
+    }
+    
+    public int port() {
+        return _port;
+    }
+    
+    public String toString() {
+        return _host + ":" + _port;
+    }
+}

--- a/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
+++ b/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
@@ -34,8 +34,6 @@ public class NimbusClient extends ThriftClient {
                     LOG.debug("Nimbus spec at ZK: "+nimbus_host_port);
                     nimbusHost = nimbus_host_port.host();
                     nimbusPort = nimbus_host_port.port();
-                    conf.put(Config.NIMBUS_HOST, nimbusHost);
-                    conf.put(Config.NIMBUS_THRIFT_PORT, (Integer)nimbusPort);
                 } catch (Exception e) {
                     LOG.warn("Failure in obtaining Nimbus host/port from Zookeeper "+zk_hosts+" port "+zk_port, e);
                 } finally {

--- a/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
+++ b/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
@@ -3,10 +3,14 @@ package backtype.storm.utils;
 import backtype.storm.Config;
 import backtype.storm.security.auth.ThriftClient;
 import backtype.storm.generated.Nimbus;
+
+import java.util.List;
 import java.util.Map;
 import org.apache.thrift7.transport.TTransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.netflix.curator.framework.CuratorFramework;
 
 public class NimbusClient extends ThriftClient {
     private Nimbus.Client _client;
@@ -16,6 +20,26 @@ public class NimbusClient extends ThriftClient {
         try {
             String nimbusHost = (String) conf.get(Config.NIMBUS_HOST);
             int nimbusPort = Utils.getInt(conf.get(Config.NIMBUS_THRIFT_PORT));
+            if (nimbusPort <= 0) {
+                List<String> zk_hosts = (List<String>)conf.get(Config.STORM_ZOOKEEPER_SERVERS);
+                Object zk_port = conf.get(Config.STORM_ZOOKEEPER_PORT);
+                CuratorFramework zk_fw = Utils.newCurator(conf, 
+                        zk_hosts,zk_port,
+                        (String) conf.get(Config.STORM_ZOOKEEPER_ROOT), 
+                        null); //auth info
+                zk_fw.start();
+                try {
+                    byte[] zk_data = zk_fw.getData().forPath("/nimbus");
+                    HostPort nimbus_host_port = (HostPort) Utils.deserialize(zk_data);
+                    LOG.info("Nimbus spec at ZK: "+nimbus_host_port);
+                    nimbusHost = nimbus_host_port.host();
+                    nimbusPort = nimbus_host_port.port();
+                } catch (Exception e) {
+                    LOG.warn("Failure in obtaining Nimbus host/port from Zookeeper "+zk_hosts+" port "+zk_port, e);
+                } finally {
+                    zk_fw.close();
+                }
+            }
             return new NimbusClient(conf, nimbusHost, nimbusPort);
         } catch (TTransportException ex) {
             throw new RuntimeException(ex);

--- a/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
+++ b/storm-core/src/jvm/backtype/storm/utils/NimbusClient.java
@@ -31,9 +31,11 @@ public class NimbusClient extends ThriftClient {
                 try {
                     byte[] zk_data = zk_fw.getData().forPath("/nimbus");
                     HostPort nimbus_host_port = (HostPort) Utils.deserialize(zk_data);
-                    LOG.info("Nimbus spec at ZK: "+nimbus_host_port);
+                    LOG.debug("Nimbus spec at ZK: "+nimbus_host_port);
                     nimbusHost = nimbus_host_port.host();
                     nimbusPort = nimbus_host_port.port();
+                    conf.put(Config.NIMBUS_HOST, nimbusHost);
+                    conf.put(Config.NIMBUS_THRIFT_PORT, (Integer)nimbusPort);
                 } catch (Exception e) {
                     LOG.warn("Failure in obtaining Nimbus host/port from Zookeeper "+zk_hosts+" port "+zk_port, e);
                 } finally {

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -274,8 +274,10 @@ public class Utils {
             return (Integer) o;
         } else if (o instanceof Short) {
             return ((Short) o).intValue();
+        } else if (o instanceof String) {
+            return Integer.parseInt((String) o);
         } else {
-            throw new IllegalArgumentException("Don't know how to convert " + o + " + to int");
+            throw new IllegalArgumentException("Don't know how to convert " + o + " (class "+o.getClass().getName()+") to int");
         }
     }
     

--- a/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
+++ b/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
@@ -38,9 +38,10 @@
            (catch Throwable t1#))))
      ))
 
-(deftest test-dynamic-nimbus-port
+(deftest test-dynamic-ports-for-nimbus-n-supervisors
   (with-server [cluster 
                 :supervisors 4 
+                :ports-per-supervisor [ 0 0 ]
                 :daemon-conf {STORM-LOCAL-MODE-ZMQ true 
                               NIMBUS-THRIFT-PORT 0}]
     (let [conf (:daemon-conf cluster)
@@ -96,3 +97,4 @@
                (is (thrown-cause? NotAliveException
                                   (.activate client "non_existing_topology"))))
       (.close nimbus))))
+

--- a/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
+++ b/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
@@ -1,0 +1,41 @@
+(ns backtype.storm.dynamic-port-test
+  (:use [clojure test])
+  (:require [backtype.storm.daemon [nimbus :as nimbus]])
+  
+  (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter])
+  (:import [backtype.storm.scheduler INimbus])
+  (:use [backtype.storm bootstrap testing])
+  (:use [backtype.storm.daemon common])
+  )
+
+(bootstrap)
+
+(deftest test-dynamic-nimbus-port
+  (with-simulated-time-local-cluster [cluster :supervisors 4 
+                                      :daemon-conf {STORM-LOCAL-MODE-ZMQ true 
+                                                    NIMBUS-THRIFT-PORT 0}]
+    (let [topology (thrift/mk-topology
+                     {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 4)}
+                     {"2" (thrift/mk-bolt-spec {"1" :shuffle} (TestGlobalCount.)
+                                               :parallelism-hint 6)})
+          results (complete-topology cluster
+                                     topology
+                                     ;; important for test that
+                                     ;; #tuples = multiple of 4 and 6
+                                     :storm-conf {TOPOLOGY-WORKERS 3}
+                                     :mock-sources {"1" [["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ["a"] ["b"]
+                                                         ]}
+                                     )]
+      (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
+               (read-tuples results "2"))))))

--- a/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
+++ b/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
@@ -1,8 +1,9 @@
 (ns backtype.storm.dynamic-port-test
   (:use [clojure test])
-  (:require [backtype.storm.daemon [nimbus :as nimbus]])
-  
+  (:require [backtype.storm.daemon [nimbus :as nimbus]])  
+  (:require [backtype.storm.ui [core :as ui]])  
   (:import [backtype.storm.testing TestWordCounter TestWordSpout TestGlobalCount TestAggregatesCounter])
+  (:import [backtype.storm.security.auth ThriftServer])
   (:import [backtype.storm.scheduler INimbus])
   (:use [backtype.storm bootstrap testing])
   (:use [backtype.storm.daemon common])
@@ -10,11 +11,39 @@
 
 (bootstrap)
 
+(defn launch-nimbus-server [conf ^Nimbus$Iface service-handler] 
+  (let [port (Integer. (conf NIMBUS-THRIFT-PORT))
+        server (ThriftServer. conf (Nimbus$Processor. service-handler) port)]
+    (.addShutdownHook (Runtime/getRuntime) (Thread. (fn [] (.stop server))))
+    (.start (Thread. #(.serve server)))
+    (wait-for-condition #(.isServing server))
+    server ))
+
+(defmacro with-server [[cluster-sym & args] & body]
+  `(let [~cluster-sym (mk-local-storm-cluster ~@args)
+         conf#   (:daemon-conf ~cluster-sym) 
+         service-handler# (:nimbus ~cluster-sym)
+         server# (launch-nimbus-server conf# service-handler#)]
+     (try
+       ~@body
+       (catch Throwable t#
+         (log-error t# "Error in cluster")
+         (throw t#)
+         )
+       (finally
+         (try 
+           (kill-local-storm-cluster ~cluster-sym)
+           (.stop server#)
+           (catch Throwable t1#))))
+     ))
+
 (deftest test-dynamic-nimbus-port
-  (with-simulated-time-local-cluster [cluster :supervisors 4 
-                                      :daemon-conf {STORM-LOCAL-MODE-ZMQ true 
-                                                    NIMBUS-THRIFT-PORT 0}]
-    (let [topology (thrift/mk-topology
+  (with-server [cluster 
+                :supervisors 4 
+                :daemon-conf {STORM-LOCAL-MODE-ZMQ true 
+                              NIMBUS-THRIFT-PORT 0}]
+    (let [conf (:daemon-conf cluster)
+          topology (thrift/mk-topology
                      {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 4)}
                      {"2" (thrift/mk-bolt-spec {"1" :shuffle} (TestGlobalCount.)
                                                :parallelism-hint 6)})
@@ -35,7 +64,21 @@
                                                          ["a"] ["b"]
                                                          ["a"] ["b"]
                                                          ["a"] ["b"]
-                                                         ]}
-                                     )]
+                                                         ]})]
+      (is (pos? (Integer. (conf NIMBUS-THRIFT-PORT))))
       (is (ms= (apply concat (repeat 6 [[1] [2] [3] [4]]))
                (read-tuples results "2"))))))
+
+(deftest test-ui-access-nimbus
+  (with-server [cluster 
+                :supervisors 0
+                :daemon-conf {STORM-LOCAL-MODE-ZMQ true 
+                              NIMBUS-THRIFT-PORT -1}]
+    (let [conf (:daemon-conf cluster)
+          ui-server-app (ui/app conf)
+          req {:uri "/" :request-method :get}
+          resp (ui-server-app req)]
+      (is (pos? (Integer. (conf NIMBUS-THRIFT-PORT))))
+      (log-message "ui server app:" ui-server-app)
+      (is (= 200 (:status resp)))
+      (is (pos? (.indexOf (:body resp) "Cluster Summary"))))))

--- a/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
+++ b/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
@@ -74,7 +74,8 @@
   (with-server [cluster 
                 :supervisors 0
                 :daemon-conf {STORM-LOCAL-MODE-ZMQ true 
-                              NIMBUS-THRIFT-PORT -1}]
+                              NIMBUS-THRIFT-PORT -1
+                              UI-PORT 0}]
     (let [conf (:daemon-conf cluster)
           ui-server-app (ui/app conf)
           req {:uri "/" :request-method :get}

--- a/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
+++ b/storm-core/test/clj/backtype/storm/dynamic_port_test.clj
@@ -32,8 +32,8 @@
          )
        (finally
          (try 
-           (kill-local-storm-cluster ~cluster-sym)
            (.stop server#)
+           (kill-local-storm-cluster ~cluster-sym)
            (catch Throwable t1#))))
      ))
 


### PR DESCRIPTION
This is one of a series pull requests, which aim to launch Storm cluster in a cluster environment.

Currently, Nimbus server and UI server launched with a configured port number. In a cloud environment, 
we don't really know which port is actually available. So, it will be convenient if Nimbus & UI server could simply 
find an available port and launch it.

In this pull request, we enable Nimbus server and UI server to find ports dynamically:
- If the nimbus port is configured to be <=0, Nimbus server will find an available port.
- If the UI port is configured to be <=0, UI server will find an available port.
  Nimbus/UI server announces the port number via Zookeeper. 

When Supervisor and UI server starts, they will pick up Nimbus host/port from Zookeeper (instead of simply reading configuration file).
