### PR TITLE
Default worker childopts: GC logging, IPv4, -server; fixes #492

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -72,7 +72,13 @@ supervisor.heartbeat.frequency.secs: 5
 supervisor.enable: true
 
 ### worker.* configs are for task workers
-worker.childopts: "-Xmx768m"
+worker.childopts: >-
+    -Xmx768m
+    -server -Djava.net.preferIPv4Stack=true
+    -Xloggc:%STORMHOME%/logs/gc-worker-%ID%.log -verbose:gc
+    -XX:GCLogFileSize=100k
+    -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCTimeStamps -XX:+PrintClassHistogram
+    -XX:+PrintTenuringDistribution -XX:-PrintGCApplicationStoppedTime
 worker.heartbeat.frequency.secs: 1
 
 task.heartbeat.frequency.secs: 3

--- a/conf/storm.yaml.example
+++ b/conf/storm.yaml.example
@@ -30,3 +30,37 @@
 #     parallelism.hint: 1
 #     argument:
 #       - endpoint: "metrics-collector.mycompany.org"
+
+#
+# Baseline JVM options: enables GC logging to storm.home/logs
+#
+worker.childopts: >-
+    -Xmx768m
+    -server -Djava.net.preferIPv4Stack=true
+    -Xloggc:%STORMHOME%/logs/gc-worker-%ID%.log -verbose:gc
+    -XX:GCLogFileSize=100k
+    -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCTimeStamps -XX:+PrintClassHistogram
+    -XX:+PrintTenuringDistribution -XX:-PrintGCApplicationStoppedTime
+#
+# # Production JVM options: verbose GC logging with rotation, expands heap size
+# # to 2.5GB and new-gen to 1GB, uses concurrent-mark-and-sweep for old-gen
+#
+# worker.childopts: >-
+#     -server -XX:+AggressiveOpts -XX:+UseCompressedOops -Djava.net.preferIPv4Stack=true
+#     -Xmx2500m -Xms2500m -Xss256k -XX:MaxPermSize=128m -XX:PermSize=96m
+#     -XX:NewSize=1000m -XX:MaxNewSize=1000m -XX:MaxTenuringThreshold=1 -XX:SurvivorRatio=6
+#     -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSParallelRemarkEnabled
+#     -XX:CMSInitiatingOccupancyFraction=75 -XX:+UseCMSInitiatingOccupancyOnly
+#     -Xloggc:%STORMHOME%/logs/gc-worker-%ID%.log -verbose:gc
+#     -XX:GCLogFileSize=1m -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10
+#     -XX:+PrintGCDetails -XX:+PrintHeapAtGC -XX:+PrintGCTimeStamps -XX:+PrintClassHistogram
+#     -XX:+PrintTenuringDistribution -XX:-PrintGCApplicationStoppedTime
+
+## Ports for child worker processes; sets the number of workers on this machine.
+## Typically, run one worker for each topology this machine will host
+# supervisor.slots.ports:
+#   - 6700
+#   - 6701
+#   - 6702
+#   - 6703
+

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -409,9 +409,9 @@
           stormjar (supervisor-stormjar-path stormroot)
           storm-conf (read-supervisor-storm-conf conf storm-id)
           classpath (add-to-classpath (current-classpath) [stormjar])
-          childopts (.replaceAll (str (conf WORKER-CHILDOPTS) " " (storm-conf TOPOLOGY-WORKER-CHILDOPTS))
-                                 "%ID%"
-                                 (str port))
+          childopts (.replaceAll (.replaceAll
+                                  (str (conf WORKER-CHILDOPTS) " " (storm-conf TOPOLOGY-WORKER-CHILDOPTS))
+                                 "%ID%" (str port)) "%STORMHOME%" (str storm-home))
           logfilename (str "worker-" port ".log")
           command (str "java -server " childopts
                        " -Djava.library.path=" (conf JAVA-LIBRARY-PATH)

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -415,7 +415,7 @@ public class Config extends HashMap<String, Object> {
 
     /**
      * The jvm opts provided to workers launched by this supervisor. All "%ID%" substrings are replaced
-     * with an identifier for this worker.
+     * with an identifier for this worker, and %STORMHOME% with the storm.home property.
      */
     public static final String WORKER_CHILDOPTS = "worker.childopts";
     public static final Object WORKER_CHILDOPTS_SCHEMA = String.class;


### PR DESCRIPTION
- Enable verbose GC tuning into {storm.home}/logs/gc-worker.log.N, capped at 100k
- added a new childopts interpolant, '%STORMHOME%', set to storm.home property at runtime.
- put example production childopts in the storm.yaml.example
- Added the 'preferIPv4Stack' setting, to make storm not bind to ipv6 interfaces by default
