### PR TITLE
Disruptor queue metrics (patch for #613)

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/builtin_metrics.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/builtin_metrics.clj
@@ -1,5 +1,5 @@
 (ns backtype.storm.daemon.builtin-metrics
-  (:import [backtype.storm.metric.api MultiCountMetric MultiReducedMetric MeanReducer])
+  (:import [backtype.storm.metric.api MultiCountMetric MultiReducedMetric MeanReducer StateMetric])
   (:import [backtype.storm Config])
   (:use [backtype.storm.stats :only [stats-rate]]))
 
@@ -36,6 +36,11 @@
     (.registerMetric topology-context (str "__" (name kw)) imetric
                      (int (get storm-conf Config/TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS)))))
           
+(defn register-queue-metrics [queues storm-conf topology-context]
+  (doseq [[qname q] queues]
+    (.registerMetric topology-context (str "__" (name qname)) (StateMetric. q)
+                     (int (get storm-conf Config/TOPOLOGY_BUILTIN_METRICS_BUCKET_SIZE_SECS)))))
+
 (defn spout-acked-tuple! [^BuiltinSpoutMetrics m stats stream latency-ms]  
   (-> m .ack-count (.scope stream) (.incrBy (stats-rate stats)))
   (-> m .complete-latency (.scope stream) (.update latency-ms)))

--- a/storm-core/src/jvm/backtype/storm/metric/api/IStatefulObject.java
+++ b/storm-core/src/jvm/backtype/storm/metric/api/IStatefulObject.java
@@ -1,0 +1,5 @@
+package backtype.storm.metric.api;
+
+public interface IStatefulObject {
+    Object getState();
+}

--- a/storm-core/src/jvm/backtype/storm/metric/api/StateMetric.java
+++ b/storm-core/src/jvm/backtype/storm/metric/api/StateMetric.java
@@ -1,0 +1,14 @@
+package backtype.storm.metric.api;
+
+public class StateMetric implements IMetric {
+    private IStatefulObject _obj;
+
+    public StateMetric(IStatefulObject obj) {
+        _obj = obj;
+    }
+
+    @Override
+    public Object getValueAndReset() {
+        return _obj.getState();
+    }
+}


### PR DESCRIPTION
- Added new metric type, 'StateMetric', to report direct metrics of anything that meets the IStatefulObject interface
- Added methods for population, capacity, and read/write head positions to Disruptor Queue; gave it a getState() to make it IStatefulObject
- Register the transfer queue and the send and receive queues for spouts and bolts.

We cheat and register the transfer queue in executor.clj because within a Java implementation of the bolt (specifically, the System bolt), we don't have access to the executor data -- we need a TopologyContext, which is only prepared for tasks. If there's a way to get this, please advise.
