### PR TITLE
fix topology.metrics.consumer.register validation: Map, not String

### DIFF
--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -554,7 +554,7 @@ public class Config extends HashMap<String, Object> {
      * Each listed class maps 1:1 to a system bolt named __metrics_ClassName#N, and it's parallelism is configurable.
      */
     public static final String TOPOLOGY_METRICS_CONSUMER_REGISTER = "topology.metrics.consumer.register";
-    public static final Object TOPOLOGY_METRICS_CONSUMER_REGISTER_SCHEMA = ConfigValidation.StringsValidator;
+    public static final Object TOPOLOGY_METRICS_CONSUMER_REGISTER_SCHEMA = ConfigValidation.MapsValidator;
 
 
     /**

--- a/storm-core/src/jvm/backtype/storm/ConfigValidation.java
+++ b/storm-core/src/jvm/backtype/storm/ConfigValidation.java
@@ -1,4 +1,5 @@
 package backtype.storm;
+import java.util.Map;
 
 /**
  * Provides functionality for validating configuration fields.
@@ -57,6 +58,11 @@ public class ConfigValidation {
      * Validates is a list of Strings.
      */
     public static Object StringsValidator = FieldListValidatorFactory(String.class);
+
+    /**
+     * Validates is a list of Maps.
+     */
+    public static Object MapsValidator = FieldListValidatorFactory(Map.class);
 
     /**
      * Validates a power of 2.


### PR DESCRIPTION
The topology.metrics.consumer.register is a list of hashes, but its schema was StringsValidator. Added a 'MapsValidator' (list of Map) and fixed the schema.
