### PR TITLE
Improve util/join-maps to remove nils 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.project
 .lein-repl-history
 /classes
 /lib

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -724,10 +724,10 @@
 
 (defn join-maps [& maps]
   (let [all-keys (apply set/union (for [m maps] (-> m keys set)))]
-    (into {}
+    (map-val #(filter identity %) (into {}
       (for [k all-keys]
         [k (for [m maps] (m k))]
-        ))))
+        )))))
 
 (defn partition-fixed [max-num-chunks aseq]
   (if (zero? max-num-chunks)


### PR DESCRIPTION
(join-maps {"c1" 2} {"c2" 1} {"c3" 3})
current, {c1 (2 nil nil), c2 (nil 1 nil), c3 (nil nil 3)}
my fix, {c1 (2), c2 (1), c3 (3)}

I also tryed other way, but the sequence of map items will be change.

``` Clojure
(defn join-maps [& maps]
"({:a 1 :b 2 :c 3} {:a 2 :c 4})->{:b (2), :c (3 4), :a (1 2)}" 
  ( map-val seq
    (reduce (fn [m map] 
            (reduce (fn [m [k,v]] (assoc m k (conj (get m k []) v))) m map))
    {} maps))
)
```

So I just remove the nils on oringal logic finally
