### PR TITLE
Filter empty args before passing to os.execvp.

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -112,13 +112,13 @@ def parse_args(string):
 
 def exec_storm_class(klass, jvmtype="-server", jvmopts=[], extrajars=[], args=[], fork=False):
     global CONFFILE
-    all_args = [
+    all_args = filter(None, [
         "java", jvmtype, get_config_opts(),
         "-Dstorm.home=" + STORM_DIR, 
         "-Djava.library.path=" + confvalue("java.library.path", extrajars),
         "-Dstorm.conf.file=" + CONFFILE,
         "-cp", get_classpath(extrajars),
-    ] + jvmopts + [klass] + list(args)
+    ] + jvmopts + [klass] + list(args))
     print "Running: " + " ".join(all_args)
     if fork:
         os.spawnvp(os.P_WAIT, "java", all_args)
@@ -139,7 +139,7 @@ def jar(jarfile, klass, *args):
         jvmtype="-client",
         extrajars=[jarfile, USER_CONF_DIR, STORM_DIR + "/bin"],
         args=args,
-        jvmopts=[JAR_JVM_OPTS + " -Dstorm.jar=" + jarfile])
+        jvmopts=[JAR_JVM_OPTS, "-Dstorm.jar=" + jarfile])
 
 def kill(*args):
     """Syntax: [storm kill topology-name [-w wait-time-secs]]


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/nathanmarz/storm/issues/657.

A `java.lang.NoClassDefFoundError` exception is thrown if `JAR_JVM_OPTS` is empty. This PR filters empty arguments before passing `all_args` to `os.execvp`.  The functionality intended by https://github.com/nathanmarz/storm/commit/0fca3034ff90c8d5de2e327d58085580fcc74256 should still remain.
