### PR TITLE
Bump httpclient in storm-core to 4.2.5.

### DIFF
--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -20,7 +20,7 @@
                  [org.clojure/math.numeric-tower "0.0.1"]
                  [storm/carbonite "1.5.0"]
                  [org.yaml/snakeyaml "1.11"]
-                 [org.apache.httpcomponents/httpclient "4.1.1"]
+                 [org.apache.httpcomponents/httpclient "4.2.5"]
                  [storm/tools.cli "0.2.2"]
                  [com.googlecode.disruptor/disruptor "2.10.1"]
                  [storm/jgrapht "0.8.3"]


### PR DESCRIPTION
This PR resolves an issue I came across when attempting use the lastest AmazonS3Client with storm. The httpclient 4.1.1 present on the classpath in the storm cluster caused an exception to occur when attempting a request with the AmazonS3Client. The aws-sdk-java library is currently including httpclient 4.2 (see [here](https://github.com/aws/aws-sdk-java/blob/master/pom.xml#L40)). This PR bumps the httpclient to 4.2.5.
