### PR TITLE
Fixes schema for isolation.scheduler.machines: Map

### DIFF
--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -777,7 +777,7 @@ public class Config extends HashMap<String, Object> {
      * to backtype.storm.scheduler.IsolationScheduler to make use of the isolation scheduler.
      */
     public static final String ISOLATION_SCHEDULER_MACHINES = "isolation.scheduler.machines";
-    public static final Object ISOLATION_SCHEDULER_MACHINES_SCHEMA = Number.class;
+    public static final Object ISOLATION_SCHEDULER_MACHINES_SCHEMA = Map.class;
 
     public static void setDebug(Map conf, boolean isOn) {
         conf.put(Config.TOPOLOGY_DEBUG, isOn);

--- a/storm-core/test/clj/backtype/storm/config_test.clj
+++ b/storm-core/test/clj/backtype/storm/config_test.clj
@@ -18,7 +18,9 @@
         (.validateField validator "test" x))))
 
     (doseq [x [64 4294967296 1 nil]]
-      (.validateField validator "test" x))))
+      (is (nil? (try 
+                  (.validateField validator "test" x)
+                  (catch Exception e e)))))))
 
 (deftest test-list-validator
   (let [validator ConfigValidation/StringsValidator]
@@ -44,7 +46,9 @@
                ["42" "64"]
                nil
               ]]
-      (.validateField validator "test" x))))
+    (is (nil? (try 
+                (.validateField validator "test" x)
+                (catch Exception e e)))))))
 
 (deftest test-topology-workers-is-number
   (let [validator (CONFIG-SCHEMA-MAP TOPOLOGY-WORKERS)]
@@ -53,3 +57,14 @@
     (.validateField validator "test" 3.14159)
     (is (thrown-cause? java.lang.IllegalArgumentException
       (.validateField validator "test" "42")))))
+
+(deftest test-isolation-scheduler-machines-is-map
+  (let [validator (CONFIG-SCHEMA-MAP ISOLATION-SCHEDULER-MACHINES)]
+    (is (nil? (try 
+                (.validateField validator "test" {}) 
+                (catch Exception e e))))
+    (is (nil? (try 
+                (.validateField validator "test" {"host0" 1 "host1" 2}) 
+                (catch Exception e e))))
+    (is (thrown-cause? java.lang.IllegalArgumentException
+      (.validateField validator "test" 42)))))


### PR DESCRIPTION
Changed other schema tests not bubble up exceptions but only to report
failure when a schema is invalid.
