### PR TITLE
May be a little bug in supervisor 

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -344,15 +344,10 @@
                         0
                         (conf SUPERVISOR-HEARTBEAT-FREQUENCY-SECS)
                         heartbeat-fn)
-    (.add event-manager synchronize-supervisor)
     (when (conf SUPERVISOR-ENABLE)
       ;; This isn't strictly necessary, but it doesn't hurt and ensures that the machine stays up
       ;; to date even if callbacks don't all work exactly right
-      (schedule-recurring (:timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor)))
-      (schedule-recurring (:timer supervisor)
-                          0
-                          (conf SUPERVISOR-MONITOR-FREQUENCY-SECS)
-                          (fn [] (.add processes-event-manager sync-processes))))
+      (schedule-recurring (:timer supervisor) 0 10 (fn [] (.add event-manager synchronize-supervisor))))
     (log-message "Starting supervisor with id " (:supervisor-id supervisor) " at host " (:my-hostname supervisor))
     (reify
      Shutdownable

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -344,6 +344,7 @@
                         0
                         (conf SUPERVISOR-HEARTBEAT-FREQUENCY-SECS)
                         heartbeat-fn)
+    (.add event-manager synchronize-supervisor)
     (when (conf SUPERVISOR-ENABLE)
       ;; This isn't strictly necessary, but it doesn't hurt and ensures that the machine stays up
       ;; to date even if callbacks don't all work exactly right


### PR DESCRIPTION
When i test supervisor .First I kill the supervisor and worker. And when the nimbus remove the assignment from this supervisor .I start  the supervisor.I got a Exception 
2013-08-23 15:45:16 event [ERROR] Error when processing event
java.io.FileNotFoundException: File 'storm-local/supervisor/stormdist/test-1-1377241347/stormconf.ser' does not exist

I think there is a bug,when the synchronize-supervisor and sync-processes execute at one time ,the sync-processes get the old assignment from the local-state when synchronize-supervisor not already put new assignment in the local-state.
