### PR TITLE
make FixedTupleSpout implement IRichSpout so it can be used for tests

### DIFF
--- a/storm-core/src/jvm/backtype/storm/testing/FixedTupleSpout.java
+++ b/storm-core/src/jvm/backtype/storm/testing/FixedTupleSpout.java
@@ -1,8 +1,10 @@
 package backtype.storm.testing;
 
-import backtype.storm.spout.ISpout;
 import backtype.storm.spout.SpoutOutputCollector;
 import backtype.storm.task.TopologyContext;
+import backtype.storm.topology.IRichSpout;
+import backtype.storm.topology.OutputFieldsDeclarer;
+import backtype.storm.tuple.Fields;
 import backtype.storm.utils.Utils;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -11,7 +13,7 @@ import java.util.Map;
 import java.util.UUID;
 import static backtype.storm.utils.Utils.get;
 
-public class FixedTupleSpout implements ISpout {
+public class FixedTupleSpout implements IRichSpout {
     private static final Map<String, Integer> acked = new HashMap<String, Integer>();
     private static final Map<String, Integer> failed = new HashMap<String, Integer>();
 
@@ -40,8 +42,13 @@ public class FixedTupleSpout implements ISpout {
     private Map<String, FixedTuple> _pending;
 
     private String _id;
-    
+    private String _fieldName;
+
     public FixedTupleSpout(List tuples) {
+        this(tuples, null);
+    }
+
+    public FixedTupleSpout(List tuples, String fieldName) {
         _id = UUID.randomUUID().toString();
         synchronized(acked) {
             acked.put(_id, 0);
@@ -59,6 +66,7 @@ public class FixedTupleSpout implements ISpout {
             }
             _tuples.add(ft);
         }
+        _fieldName = fieldName;
     }
 
     public List<FixedTuple> getSourceTuples() {
@@ -138,5 +146,17 @@ public class FixedTupleSpout implements ISpout {
 
     @Override
     public void deactivate() {
+    }
+
+    @Override
+    public void declareOutputFields(OutputFieldsDeclarer declarer) { 
+        if (_fieldName != null) {
+            declarer.declare(new Fields(_fieldName));
+        }
+    }
+
+    @Override
+    public Map<String, Object> getComponentConfiguration() {
+        return null;
     }
 }


### PR DESCRIPTION
The Summingbird guys want to use FixedTupleSpout explicitly in tests (rather implicitly via the :mock-sources argument to complete-topology).
