### PR TITLE
Ignoring a FileNotFound excpetion that can bring down a supervisor.

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -1,4 +1,5 @@
 (ns backtype.storm.daemon.supervisor
+  (:import [java.io IOException])
   (:import [backtype.storm.scheduler ISupervisor])
   (:use [backtype.storm bootstrap])
   (:use [backtype.storm.daemon common])
@@ -142,6 +143,8 @@
     ;; this avoids a race condition with worker or subprocess writing pid around same time
     (rmpath (worker-pids-root conf id))
     (rmpath (worker-root conf id))
+  (catch IOException e
+    (log-warn-error e "Failed to cleanup worker " id ". Will retry later"))
   (catch RuntimeException e
     (log-warn-error e "Failed to cleanup worker " id ". Will retry later")
     )))

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -1,5 +1,4 @@
 (ns backtype.storm.daemon.supervisor
-  (:import [java.io IOException])
   (:import [backtype.storm.scheduler ISupervisor])
   (:use [backtype.storm bootstrap])
   (:use [backtype.storm.daemon common])
@@ -143,8 +142,6 @@
     ;; this avoids a race condition with worker or subprocess writing pid around same time
     (rmpath (worker-pids-root conf id))
     (rmpath (worker-root conf id))
-  (catch IOException e
-    (log-warn-error e "Failed to cleanup worker " id ". Will retry later"))
   (catch RuntimeException e
     (log-warn-error e "Failed to cleanup worker " id ". Will retry later")
     )))

--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -1,7 +1,7 @@
 (ns backtype.storm.util
   (:import [java.net InetAddress])
   (:import [java.util Map Map$Entry List ArrayList Collection Iterator HashMap])
-  (:import [java.io FileReader])
+  (:import [java.io FileReader FileNotFoundException])
   (:import [backtype.storm Config])
   (:import [backtype.storm.utils Time Container ClojureTimerTask Utils
             MutableObject MutableInt])
@@ -431,7 +431,9 @@
 (defn rmr [path]
   (log-debug "Rmr path " path)
   (when (exists-file? path)
-    (FileUtils/forceDelete (File. path))))
+    (try
+      (FileUtils/forceDelete (File. path))
+    (catch FileNotFoundException e))))
 
 (defn rmpath
   "Removes file or directory at the path. Not recursive. Throws exception on failure"


### PR DESCRIPTION
When running tests we found a race. kill_local_storm_cluster in testing.clj tries to shut down the supervisor and kill all running workers using try_worker_cleanup.  At the same time a worker may have exited and the sync_process would also call try_worker_cleanup.  The last one called gets a FileNotFoundException from the call to rmr.  rmr can also throw an IOException if there are other issues with deleting the directory.  I thought it was best just to ignore this error like we do RuntimeExceptions thrown by rmpath.
