### PR TITLE
ui and log viewer send proper html pages

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -44,7 +44,7 @@
     (str "effective log level for " name " is " (.getLevel (.getLogger log)))))
 
 (defn log-template [body]
-  (html
+  (html4
    [:head
     [:title "Storm log viewer"]
     (include-css "/css/bootstrap-1.1.0.css")

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -39,7 +39,7 @@
              :onclick "toggleSys()"}]])
 
 (defn ui-template [body]
-  (html
+  (html4
    [:head
     [:title "Storm UI"]
     (include-css "/css/bootstrap-1.1.0.css")


### PR DESCRIPTION
Currently the response body starts with `<head>`.  Using `html4` will bookend the document with the proper tags and declarations.
