### PR TITLE
Fixes build_release.sh issue when using leiningen v2.3

### DIFF
--- a/storm-console-logging/project.clj
+++ b/storm-console-logging/project.clj
@@ -3,6 +3,7 @@
 
 (defproject storm/storm-console-logging VERSION
   :resource-paths ["logback"]
+  :target-path "target"
 
   :profiles {:release {}
              }

--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -33,6 +33,7 @@
   :java-source-paths ["src/jvm"]
   :test-paths ["test/clj"]
   :resource-paths ["../conf"]
+  :target-path "target"
 
   :profiles {:dev {:resource-paths ["src/dev"]
                    :dependencies [[org.mockito/mockito-all "1.9.5"]]}

--- a/storm-lib/project.clj
+++ b/storm-lib/project.clj
@@ -14,4 +14,5 @@
                  :post "storm-user@googlegroups.com"}
   :dependencies [~@DEPENDENCIES]
   :min-lein-version "2.0.0"
+  :target-path "target"
   ))

--- a/storm-netty/project.clj
+++ b/storm-netty/project.clj
@@ -8,4 +8,5 @@
   :test-paths ["test/clj"]
   :profiles {:release {}}
   :jvm-opts ["-Djava.library.path=/usr/local/lib:/opt/local/lib:/usr/lib"]
+  :target-path "target"
   :aot :all))


### PR DESCRIPTION
latest version of leiningen breaks bin/build_release.sh creating zip without jar files. This fixes it by forcing lein to store jar in the same path it use to, target/... instead of target/profile-name/...

Steps to reproduce:
1. invoke bin/build_release.sh with leiningen version = 2.3.2+, you will see the zip file does not contain any jars. 
