### PR TITLE
Wrapping all curator exceptions in RuntimeExceptions.

### DIFF
--- a/storm-core/src/clj/backtype/storm/util.clj
+++ b/storm-core/src/clj/backtype/storm/util.clj
@@ -22,6 +22,13 @@
   (:use [backtype.storm log])
   )
 
+(defn wrap-in-runtime
+  "Wraps an exception in a RuntimeException if needed" 
+  [^Exception e]
+  (if (instance? RuntimeException e)
+    e
+    (RuntimeException. e)))
+
 (defmacro defalias
   "Defines an alias for a var: a new var with the same root binding (if
   any) and similar metadata. The metadata of the alias is its initial

--- a/storm-core/src/clj/backtype/storm/zookeeper.clj
+++ b/storm-core/src/clj/backtype/storm/zookeeper.clj
@@ -67,21 +67,25 @@
 
 (defn create-node
   ([^CuratorFramework zk ^String path ^bytes data mode]
-    (.. zk (create) (withMode (zk-create-modes mode)) (withACL ZooDefs$Ids/OPEN_ACL_UNSAFE) (forPath (normalize-path path) data)))
+    (try
+      (.. zk (create) (withMode (zk-create-modes mode)) (withACL ZooDefs$Ids/OPEN_ACL_UNSAFE) (forPath (normalize-path path) data))
+      (catch Exception e (throw (RuntimeException. e)))))
   ([^CuratorFramework zk ^String path ^bytes data]
     (create-node zk path data :persistent)))
 
 (defn exists-node? [^CuratorFramework zk ^String path watch?]
   ((complement nil?)
-    (if watch?
-       (.. zk (checkExists) (watched) (forPath (normalize-path path))) 
-       (.. zk (checkExists) (forPath (normalize-path path))))))
+    (try
+      (if watch?
+         (.. zk (checkExists) (watched) (forPath (normalize-path path))) 
+         (.. zk (checkExists) (forPath (normalize-path path))))
+      (catch Exception e (throw (RuntimeException. e))))))
 
 (defnk delete-node [^CuratorFramework zk ^String path :force false]
   (try-cause  (.. zk (delete) (forPath (normalize-path path)))
     (catch KeeperException$NoNodeException e
-      (when-not force (throw e))
-      )))
+      (when-not force (throw e)))
+    (catch Exception e (throw (RuntimeException. e)))))
 
 (defn mkdirs [^CuratorFramework zk ^String path]
   (let [path (normalize-path path)]
@@ -103,15 +107,20 @@
           (.. zk (getData) (forPath path))))
     (catch KeeperException$NoNodeException e
       ;; this is fine b/c we still have a watch from the successful exists call
-      nil ))))
+      nil )
+    (catch Exception e (throw (RuntimeException. e))))))
 
 (defn get-children [^CuratorFramework zk ^String path watch?]
-  (if watch?
-    (.. zk (getChildren) (watched) (forPath (normalize-path path)))
-    (.. zk (getChildren) (forPath (normalize-path path)))))
+  (try
+    (if watch?
+      (.. zk (getChildren) (watched) (forPath (normalize-path path)))
+      (.. zk (getChildren) (forPath (normalize-path path))))
+      (catch Exception e (throw (RuntimeException. e)))))
 
 (defn set-data [^CuratorFramework zk ^String path ^bytes data]
-  (.. zk (setData) (forPath (normalize-path path) data)))
+  (try
+    (.. zk (setData) (forPath (normalize-path path) data))
+    (catch Exception e (throw (RuntimeException. e)))))
 
 (defn exists [^CuratorFramework zk ^String path watch?]
   (exists-node? zk path watch?))

--- a/storm-core/src/clj/backtype/storm/zookeeper.clj
+++ b/storm-core/src/clj/backtype/storm/zookeeper.clj
@@ -69,7 +69,7 @@
   ([^CuratorFramework zk ^String path ^bytes data mode]
     (try
       (.. zk (create) (withMode (zk-create-modes mode)) (withACL ZooDefs$Ids/OPEN_ACL_UNSAFE) (forPath (normalize-path path) data))
-      (catch Exception e (throw (RuntimeException. e)))))
+      (catch Exception e (throw (wrap-in-runtime e)))))
   ([^CuratorFramework zk ^String path ^bytes data]
     (create-node zk path data :persistent)))
 
@@ -79,13 +79,13 @@
       (if watch?
          (.. zk (checkExists) (watched) (forPath (normalize-path path))) 
          (.. zk (checkExists) (forPath (normalize-path path))))
-      (catch Exception e (throw (RuntimeException. e))))))
+      (catch Exception e (throw (wrap-in-runtime e))))))
 
 (defnk delete-node [^CuratorFramework zk ^String path :force false]
   (try-cause  (.. zk (delete) (forPath (normalize-path path)))
     (catch KeeperException$NoNodeException e
       (when-not force (throw e)))
-    (catch Exception e (throw (RuntimeException. e)))))
+    (catch Exception e (throw (wrap-in-runtime e)))))
 
 (defn mkdirs [^CuratorFramework zk ^String path]
   (let [path (normalize-path path)]
@@ -108,19 +108,19 @@
     (catch KeeperException$NoNodeException e
       ;; this is fine b/c we still have a watch from the successful exists call
       nil )
-    (catch Exception e (throw (RuntimeException. e))))))
+    (catch Exception e (throw (wrap-in-runtime e))))))
 
 (defn get-children [^CuratorFramework zk ^String path watch?]
   (try
     (if watch?
       (.. zk (getChildren) (watched) (forPath (normalize-path path)))
       (.. zk (getChildren) (forPath (normalize-path path))))
-      (catch Exception e (throw (RuntimeException. e)))))
+    (catch Exception e (throw (wrap-in-runtime e)))))
 
 (defn set-data [^CuratorFramework zk ^String path ^bytes data]
   (try
     (.. zk (setData) (forPath (normalize-path path) data))
-    (catch Exception e (throw (RuntimeException. e)))))
+    (catch Exception e (throw (wrap-in-runtime e)))))
 
 (defn exists [^CuratorFramework zk ^String path watch?]
   (exists-node? zk path watch?))


### PR DESCRIPTION
Recently we ran into a situation where an InterruptedException was being thrown from IOutputCollector.reportError, even though InterruptedException is not a RuntimeException.  Many of the Curator APIs actually declare that any Exception can be thrown.  To avoid non-runtime exceptions being thrown by a java API that does not declare it, this patch wraps any Exception thrown by the curator API in a RuntimeException. 
