### PR TITLE
Update nimbus.clj

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -855,7 +855,8 @@
 (defn validate-topology-name! [name]
   (if (some #(.contains name %) DISALLOWED-TOPOLOGY-NAME-STRS)
     (throw (InvalidTopologyException.
-            (str "Topology name cannot contain any of the following: " (pr-str DISALLOWED-TOPOLOGY-NAME-STRS))))))
+            (str "Topology name cannot contain any of the following: " (pr-str DISALLOWED-TOPOLOGY-NAME-STRS))))
+              (if (clojure.string/blank? name) (throw (InvalidTopologyException. (str "Topology name cannot be blank"))))))
 
 (defn- try-read-storm-conf [conf storm-id]
   (try-cause

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -856,7 +856,8 @@
   (if (some #(.contains name %) DISALLOWED-TOPOLOGY-NAME-STRS)
     (throw (InvalidTopologyException.
             (str "Topology name cannot contain any of the following: " (pr-str DISALLOWED-TOPOLOGY-NAME-STRS))))
-              (if (clojure.string/blank? name) (throw (InvalidTopologyException. (str "Topology name cannot be blank"))))))
+  (if (clojure.string/blank? name) 
+    (throw (InvalidTopologyException. (str "Topology name cannot be blank"))))))
 
 (defn- try-read-storm-conf [conf storm-id]
   (try-cause

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -858,7 +858,7 @@
             (str "Topology name cannot contain any of the following: " (pr-str DISALLOWED-TOPOLOGY-NAME-STRS))))
   (if (clojure.string/blank? name) 
     (throw (InvalidTopologyException. 
-            (str "Topology name cannot be blank"))))))
+            ("Topology name cannot be blank"))))))
 
 (defn- try-read-storm-conf [conf storm-id]
   (try-cause

--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -857,7 +857,8 @@
     (throw (InvalidTopologyException.
             (str "Topology name cannot contain any of the following: " (pr-str DISALLOWED-TOPOLOGY-NAME-STRS))))
   (if (clojure.string/blank? name) 
-    (throw (InvalidTopologyException. (str "Topology name cannot be blank"))))))
+    (throw (InvalidTopologyException. 
+            (str "Topology name cannot be blank"))))))
 
 (defn- try-read-storm-conf [conf storm-id]
   (try-cause


### PR DESCRIPTION
![screen shot 2013-09-03 at 11 36 45 am](https://f.cloud.github.com/assets/3344813/1075120/dba5ca5c-14c7-11e3-874a-8df3c147586c.png)

Adding check to disallow topology submission if the topology name is blank. In one of the scenarios, we had pushed a topology with an empty name, and it showed up on the ui with only the uid. Also since it did not have any name we could not go into "Topology Details" to kill it, and hence had to clean up the state on the disk so that Nimbus kills the topology.
