### PR TITLE
When scheduling make sure to clean up empty assignments in zookeeper.

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/nimbus.clj
@@ -651,6 +651,7 @@
                                        topologies
                                        scratch-topology-id)
         
+        topology->executor->node+port (merge (into {} (for [id assigned-topology-ids] {id nil})) topology->executor->node+port)
         
         now-secs (current-time-secs)
         

--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -47,7 +47,7 @@
   "Returns map from port to struct containing :storm-id and :executors"
   [assignments-snapshot assignment-id]
   (->> (dofor [sid (keys assignments-snapshot)] (read-my-executors assignments-snapshot sid assignment-id))
-       (apply merge-with (fn [& ignored] (throw-runtime "Should not have multiple topologies assigned to one port")))))
+       (apply merge-with (fn [& params] (throw-runtime (str "Should not have multiple topologies assigned to one port " params))))))
 
 (defn- read-storm-code-locations
   [assignments-snapshot]


### PR DESCRIPTION
This should fix https://github.com/nathanmarz/storm/issues/551 The part when re-balancing causes the scheduled topologies to be in a bad state inside of ZK.  It does not fix the race between updating nimbus writing new scheduling info and a supervisor trying to read that information.  It also does not do anything to try and clean up workers that were running previously, but are not longer running.  This can result in nimbus complaining about the workers no longer being alive when checking heartbeat timeouts.  If this is important I can go back and try to see if there is something I can do to clean that up as well.
