### PR TITLE
Two patches to scheduler

### DIFF
--- a/storm-core/src/clj/backtype/storm/scheduler/DefaultScheduler.clj
+++ b/storm-core/src/clj/backtype/storm/scheduler/DefaultScheduler.clj
@@ -55,8 +55,8 @@
                                     (not= alive-executors all-executors))
                                 (bad-slots alive-assigned (count all-executors) total-slots-to-use)
                                 [])]]
-      (.freeSlots cluster bad-slots)
-      (EvenScheduler/schedule-topologies-evenly (Topologies. {topology-id topology}) cluster))))
+      (.freeSlots cluster bad-slots))
+    (EvenScheduler/schedule-topologies-evenly (Topologies. {topology-id topology}) cluster)))
 
 (defn -schedule [this ^Topologies topologies ^Cluster cluster]
   (default-schedule topologies cluster))

--- a/storm-core/src/jvm/backtype/storm/scheduler/SchedulerAssignmentImpl.java
+++ b/storm-core/src/jvm/backtype/storm/scheduler/SchedulerAssignmentImpl.java
@@ -2,7 +2,7 @@ package backtype.storm.scheduler;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +21,7 @@ public class SchedulerAssignmentImpl implements SchedulerAssignment {
     
     public SchedulerAssignmentImpl(String topologyId, Map<ExecutorDetails, WorkerSlot> executorToSlots) {
         this.topologyId = topologyId;
-        this.executorToSlot = new HashMap<ExecutorDetails, WorkerSlot>(0);
+        this.executorToSlot = new LinkedHashMap<ExecutorDetails, WorkerSlot>(0);
         if (executorToSlots != null) {
             this.executorToSlot.putAll(executorToSlots);
         }


### PR DESCRIPTION
There are two patches here:
1. There seems to be an erroneous structure in `default-schedule`: invoking to `schedule-topologies-evenly` should only be done **after** freeing all `bad-slots` for topologies that needs re-scheduling.
2. `SchedulerAssignmentImpl` currently uses `HashMap`, which **does not** preserve entries order.  This can cause unnecessary and unexpected re-scheduling when nimbus converts `executor->node+port` between its internal Clojure maps and `SchedulerAssignmentImpl`'s Java maps back and forth.
