### PR TITLE
Pass full topology information to ShellSpout/ShellBolt

### DIFF
--- a/storm-core/src/jvm/backtype/storm/task/GeneralTopologyContext.java
+++ b/storm-core/src/jvm/backtype/storm/task/GeneralTopologyContext.java
@@ -140,8 +140,35 @@ public class GeneralTopologyContext implements JSONAware {
     public String toJSONString() {
         Map obj = new HashMap();
         obj.put("task->component", _taskToComponent);
-        // TODO: jsonify StormTopology
-        // at the minimum should send source info
+        Map bolts = _topology.get_bolts();
+        Map spouts = _topology.get_spouts();
+        for (String compId : _taskToComponent.values()) {
+            Map compMap = new HashMap();
+            if (bolts.containsKey(compId)) {
+                List<String> jsonSources = new ArrayList<String>();
+                Map<GlobalStreamId, Grouping> sources = getSources(compId);
+                for (GlobalStreamId sourceId : sources.keySet()) {
+                    jsonSources.add(sourceId.get_componentId());
+                }
+                compMap.put("sources", jsonSources);
+            }
+
+            if (spouts.containsKey(compId) || bolts.containsKey(compId)) {
+                List<String> jsonTargets = new ArrayList<String>();
+                for (Map<String, Grouping> targets : getTargets(compId).values()) {
+                    for (String target : targets.keySet()) {
+                        jsonTargets.add(target);
+                    }
+                }
+                if (!jsonTargets.isEmpty()) {
+                    compMap.put("targets", jsonTargets);
+                }
+            }
+
+            if (!compMap.isEmpty()) {
+                obj.put(compId, compMap);
+            }
+        }
         return JSONValue.toJSONString(obj);
     }
 

--- a/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
+++ b/storm-core/src/jvm/backtype/storm/utils/ShellProcess.java
@@ -40,6 +40,7 @@ public class ShellProcess {
         setupInfo.put("pidDir", context.getPIDDir());
         setupInfo.put("conf", conf);
         setupInfo.put("context", context);
+        setupInfo.put("componentId", context.getThisComponentId());
         writeMessage(setupInfo);
 
         return (Number)readMessage().get("pid");

--- a/storm-core/src/multilang/py/storm.py
+++ b/storm-core/src/multilang/py/storm.py
@@ -121,7 +121,9 @@ def log(msg):
 def initComponent():
     setupInfo = readMsg()
     sendpid(setupInfo['pidDir'])
-    return [setupInfo['conf'], setupInfo['context']]
+    context = setupInfo['context']
+    context['componentId'] = setupInfo['conponentId']
+    return setupInfo['conf'], context
 
 class Tuple(object):
     def __init__(self, id, component, stream, task, values):


### PR DESCRIPTION
The subprocesses running under ShellBolt ShellSpout should have information about the topology context they run in, specifically their component ID and the sources and targets.

I think there is already a todo note in GeneralTopologyContext.toJSONString for this.
