### PR TITLE
close #351. in storm.py: turn off stdout to avoid messing with JSON payload sent back to JAVA layer

### DIFF
--- a/storm-core/src/multilang/py/storm.py
+++ b/storm-core/src/multilang/py/storm.py
@@ -55,9 +55,9 @@ def readTuple():
     return Tuple(cmd["id"], cmd["comp"], cmd["stream"], cmd["task"], cmd["tuple"])
 
 def sendMsgToParent(msg):
-    print json_encode(msg)
-    print "end"
-    sys.stdout.flush()
+    original_stdout.write(json_encode(msg) + '\n')
+    original_stdout.write("end\n")
+    original_stdout.flush()
 
 def sync():
     sendMsgToParent({'command':'sync'})
@@ -122,6 +122,28 @@ def initComponent():
     setupInfo = readMsg()
     sendpid(setupInfo['pidDir'])
     return [setupInfo['conf'], setupInfo['context']]
+
+# prevent custom code's print methods pollute stdout, resulting in wrong
+# message sent to JAVA layer.
+
+original_stdout = sys.stdout
+
+def nullify_stdout(func):
+    # a wrapper function nullify all print methods of its wrapped funcs.
+
+    class NullDevice():
+        def write(self, s):
+            pass
+
+    def wrapper(*args):
+        sys.stdout = NullDevice()
+        try:
+            result = func(*args)
+        finally:
+            sys.stdout = original_stdout
+        return result
+
+    return wrapper
 
 class Tuple(object):
     def __init__(self, id, component, stream, task, values):


### PR DESCRIPTION
 I write a python decorator to silence prints' output into stdout. Meanwhile sendMsgToParent() function doesn't get affected, so the communication to Java Layer is not affected, too. Use this wrapper on any custom python scripts containing prints without worrying those prints would mess up the tuple emits. I tested with storm-starter's WordCountTopology.
