### PR TITLE
Makes JNI simpler on storm.

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/supervisor.clj
@@ -401,10 +401,10 @@
       ))
 
 (defn jlp [stormroot conf]
-  (let [resource-root (str stormroot "/" RESOURCES-SUBDIR)
+  (let [resource-root (str stormroot File/pathSeparator RESOURCES-SUBDIR)
         os (clojure.string/replace (System/getProperty "os.name") #"\s+" "_")
         arch (System/getProperty "os.arch")
-        arch-resource-root (str resource-root "/" os "-" arch)]
+        arch-resource-root (str resource-root File/pathSeparator os "-" arch)]
     (str arch-resource-root ":" resource-root ":" (conf JAVA-LIBRARY-PATH))))
 
 (defmethod launch-worker


### PR DESCRIPTION
This patch allows native libraries to be included in the topology jar like scripts for shell bolts and spouts.  The native library and its dependencies can be placed in either the resources directory or in resources/$(os.name)-$(os.arch)/

I have tested this manually, but I am not totally sure how to write a unit test for this.  It simply modifies the worker command line to include the appropriate directory.  After this is reviewed I am happy to also put up a pull request for the twiki describing how to use it.
