### PR TITLE
fix the issue that tick tuple cannot work with system bolt

### DIFF
--- a/storm-core/src/clj/backtype/storm/daemon/executor.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/executor.clj
@@ -283,9 +283,10 @@
         receive-queue (:receive-queue executor-data)
         context (:worker-context executor-data)]
     (when tick-time-secs
-      (if (and (not (storm-conf TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS))
-               (= :spout (:type executor-data)))
-        (log-message "Timeouts disabled for executor " (:executor-id executor-data))
+      (if (or (system-id? (:component-id executor-data))
+              (and (not (storm-conf TOPOLOGY-ENABLE-MESSAGE-TIMEOUTS))
+                   (= :spout (:type executor-data))))
+        (log-message "Timeouts disabled for executor " (:component-id executor-data) ":" (:executor-id executor-data))
         (schedule-recurring
           (:user-timer worker)
           tick-time-secs

--- a/storm-core/test/clj/backtype/storm/tick_tuple_test.clj
+++ b/storm-core/test/clj/backtype/storm/tick_tuple_test.clj
@@ -1,0 +1,35 @@
+(ns backtype.storm.tick-tuple-test
+  (:use [clojure test])
+  (:use [backtype.storm bootstrap testing])
+  (:use [backtype.storm.daemon common]))
+
+(bootstrap)
+
+(defbolt noop-bolt ["tuple"] {:prepare true}
+  [conf context collector]
+  (bolt
+   (execute [tuple])))
+
+(defspout noop-spout ["tuple"]
+  [conf context collector]
+  (spout
+   (nextTuple [])))
+
+(deftest test-tick-tuple-works-with-system-bolt
+  (with-simulated-time-local-cluster [cluster]
+    (let [topology (thrift/mk-topology
+                    {"1" (thrift/mk-spout-spec noop-spout)}
+                    {"2" (thrift/mk-bolt-spec {"1" ["tuple"]} noop-bolt)})]
+      (try
+        (submit-local-topology (:nimbus cluster)
+                               "test"
+                               {TOPOLOGY-TICK-TUPLE-FREQ-SECS 1}
+                               topology)
+        (advance-cluster-time cluster 2)
+        ;; if reaches here, it means everything works ok.
+        (is true)
+        (catch Exception e
+          (is false))))))
+
+
+


### PR DESCRIPTION
This patch fix #699 by not setup ticks for system components.
