### PR TITLE
logviewer tries to determine log directory via logback configuration

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -40,6 +40,7 @@ ui.childopts: "-Xmx768m"
 
 logviewer.port: 8000
 logviewer.childopts: "-Xmx128m"
+logviewer.appender.name: "A1"
 
 
 drpc.port: 3772

--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -38,10 +38,8 @@ Note that if anything goes wrong, this will throw an Error and exit."
   (let [appender (.getAppender (LoggerFactory/getLogger Logger/ROOT_LOGGER_NAME) appender-name)]
     (if (and appender-name appender (instance? FileAppender appender))
       (.getParent (File. (.getFile appender)))
-      (do
-        (throw
-         (Error. "Log viewer could not find configured appender, or the appender is not a FileAppender. Please check that the appender name configured in storm.yaml and cluster.xml agree."))
-        (System/exit 1)))))
+      (throw
+       (RuntimeException. "Log viewer could not find configured appender, or the appender is not a FileAppender. Please check that the appender name configured in storm and logback agree.")))))
 
 (defn log-page [file tail grep root-dir]
   (let [path (.getCanonicalPath (File. root-dir file))

--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -9,6 +9,7 @@
   (:import [org.apache.commons.logging.impl Log4JLogger])
   (:import [ch.qos.logback.core FileAppender])
   (:import [org.apache.log4j Level])
+  (:import [java.io File])
   (:require [compojure.route :as route]
             [compojure.handler :as handler]
             [clojure.string :as string])
@@ -33,13 +34,11 @@
   []
   (let [appender (first (iterator-seq (.iteratorForAppenders (LoggerFactory/getLogger Logger/ROOT_LOGGER_NAME))))]
     (if (and appender (instance? FileAppender appender))
-      (string/join
-       "/" (butlast
-            (string/split (.getFile appender) #"/")))
-      (str (System/getProperty "storm.home") "/logs/"))))
+      (.getParent (File. (.getFile appender)))
+      (.getCanonicalPath (File. (System/getProperty "storm.home") "logs")))))
 
 (defn log-page [file tail grep]
-  (let [path (str (log-root-dir) "/" file)
+  (let [path (.getCanonicalPath (File. (log-root-dir) file))
         tail (if tail
                (min 10485760 (Integer/parseInt tail))
                10240)

--- a/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
+++ b/storm-core/src/clj/backtype/storm/daemon/logviewer.clj
@@ -92,8 +92,8 @@ Note that if anything goes wrong, this will throw an Error and exit."
   (fn [req]
     (app (assoc req :log-root log-root))))
 
-(defn start-logviewer [port conf]
-  (run-jetty (conf-middleware logapp conf) {:port port}))
+(defn start-logviewer [port log-root]
+  (run-jetty (conf-middleware logapp log-root) {:port port}))
 
 (defn -main []
   (let [conf (read-storm-config)

--- a/storm-core/src/jvm/backtype/storm/Config.java
+++ b/storm-core/src/jvm/backtype/storm/Config.java
@@ -313,6 +313,12 @@ public class Config extends HashMap<String, Object> {
     public static final Object LOGVIEWER_CHILDOPTS_SCHEMA = String.class;
 
     /**
+     * Appender name used by log viewer to determine log directory.
+     */
+    public static final String LOGVIEWER_APPENDER_NAME = "logviewer.appender.name";
+    public static final Object LOGVIEWER_APPENDER_NAME_SCHEMA = String.class;
+
+    /**
      * Childopts for Storm UI Java process.
      */
     public static final String UI_CHILDOPTS = "ui.childopts";


### PR DESCRIPTION
This introduces a new config variable, `logviewer.appender.name`, and modifies the logviewer process to locate the root log directory based on the the `FileAppender` named in the conf. Previously the logviewer assumed that the log directory was `{storm.home}/logs`.

If the named appender is not found or is not a `FileAppender` then the logviewer immediately throws a `RuntimeException`.

This issue is mentioned on the mailing list here: https://groups.google.com/d/msg/storm-user/IKRtIkqQfqc/OUDvyU6mxTMJ
