### PR TITLE
Fix sys stats cookie being lost from UI requests

### DIFF
--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -803,7 +803,7 @@
         ))))
 
 (def app
-  (-> #'main-routes
+  (-> main-routes
       (wrap-reload '[backtype.storm.ui.core])
       catch-errors))
 

--- a/storm-core/src/clj/backtype/storm/ui/core.clj
+++ b/storm-core/src/clj/backtype/storm/ui/core.clj
@@ -803,9 +803,9 @@
         ))))
 
 (def app
-  (-> main-routes
-      (wrap-reload '[backtype.storm.ui.core])
-      catch-errors))
+  (handler/site (-> main-routes
+                    (wrap-reload '[backtype.storm.ui.core])
+                    catch-errors)))
 
 (defn start-server! [] (run-jetty app {:port (Integer. (*STORM-CONF* UI-PORT))
                                        :join? false}))


### PR DESCRIPTION
Undo part of a change introduced with 7694401ddf8bc8c988dd70414f1aae8d1540e02b

This fixes a possible regression from 0.9.0 introduced in 0.9.0-rc1
