### PR TITLE
Ability to parse multi value -c arguments on the commandline

### DIFF
--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -136,17 +136,44 @@ public class Utils {
     public static Map readDefaultConfig() {
         return findAndReadConfigFile("defaults.yaml", true);
     }
-    
+
     public static Map readCommandLineOpts() {
         Map ret = new HashMap();
         String commandOptions = System.getProperty("storm.options");
-        if(commandOptions != null) {
+        if (commandOptions != null) {
             commandOptions = commandOptions.replaceAll("%%%%", " ");
+
             String[] configs = commandOptions.split(",");
-            for (String config : configs) {
-                String[] options = config.split("=");
-                if (options.length == 2) {
+            String lastArgKey = null;
+            for (int i = 0; i < configs.length; i++) {
+                if (configs[i].contains("=")) {
+                    // we have a key value pair -> split it
+                    String[] options = configs[i].split("=");
                     ret.put(options[0], options[1]);
+                    lastArgKey = options[0];
+                } else {
+                    // list value, please add to previous full one
+                    ret.put(lastArgKey, ret.get(lastArgKey) + "," + configs[i]);
+                }
+            }
+
+            // If we have a list argument make it an actual list of the right type
+            for (Object key : ret.keySet()) {
+                String[] options = ret.get(key).toString().split(",");
+                if (options.length > 1) {
+                    // make a list out of it otherwise leave it as is
+                    if (StringUtils.isNumeric(options[0])) {
+                        ArrayList nums = new ArrayList(options.length);
+                        for(String num : options){
+                            nums.add(Long.parseLong(num));
+                        }
+                        ret.put(key, nums);
+                    } else {
+                        // fix type for single value numeric params
+                        if (StringUtils.isNumeric(options[0])) {
+                            ret.put(key, Long.parseLong(options[0]));
+                        }
+                    }
                 }
             }
         }

--- a/storm-core/src/jvm/backtype/storm/utils/Utils.java
+++ b/storm-core/src/jvm/backtype/storm/utils/Utils.java
@@ -21,6 +21,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -169,10 +170,8 @@ public class Utils {
                         }
                         ret.put(key, nums);
                     } else {
-                        // fix type for single value numeric params
-                        if (StringUtils.isNumeric(options[0])) {
-                            ret.put(key, Long.parseLong(options[0]));
-                        }
+                        // fix type for string values
+                        ret.put(key, Arrays.asList(options));
                     }
                 }
             }


### PR DESCRIPTION
Hi!

The following patch enables lists of values to be parsed on the CLI via the `-c` argument.
This way one can configure Nimbus and Supervisors almost entirely from the CLI.
It is fully backwards compatible and only provides better parsing logic to distinguish keys from lists of values.

Sample:

```
bin/storm-mesos nimbus -c java.library.path=native:/usr/local/lib,mesos.master.url=master1:5050,mesos.executor.uri=http://mydomain.com/storm-mesos-0.8.3-wip3.tgz,nimbus.host=myMaster,storm.local.dir=../storm-local,ui.port=7070,storm.zookeeper.servers=zk0,zk1,zk2
```

We use it to run Storm on Mesos, but the patch is generic and benefits regular Storm CLI parsing.
I do have tests, but didn't see a standard way to trigger tests for utility functions like this.
Thanks!
-Erich
