### PR TITLE
Adding error command handling to ShellSpout.

### DIFF
--- a/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -88,6 +88,10 @@ public class ShellSpout implements ISpout {
                 } else if (command.equals("log")) {
                     String msg = (String) action.get("msg");
                     LOG.info("Shell msg: " + msg);
+                } else if (command.equals("error")) {
+                    String msg = (String) action.get("msg");
+                    _collector.reportError(new Exception("Shell Process Exception: " + msg));
+                    return;
                 } else if (command.equals("emit")) {
                     String stream = (String) action.get("stream");
                     if (stream == null) stream = Utils.DEFAULT_STREAM_ID;


### PR DESCRIPTION
The ShellBolt has an equivalent case for handling "error" commands so I thought it would be appropriate for the ShellSpout to have one too.
