### PR TITLE
Ensure we don't overflow the backoff value.

### DIFF
--- a/conf/defaults.yaml
+++ b/conf/defaults.yaml
@@ -86,7 +86,7 @@ zmq.hwm: 0
 storm.messaging.netty.server_worker_threads: 1
 storm.messaging.netty.client_worker_threads: 1
 storm.messaging.netty.buffer_size: 5242880 #5MB buffer
-storm.messaging.netty.max_retries: 100
+storm.messaging.netty.max_retries: 30
 storm.messaging.netty.max_wait_ms: 1000
 storm.messaging.netty.min_wait_ms: 100
 


### PR DESCRIPTION
The first attempt to fix this (213102b36f890) did not correctly address
the issue.  The 32 bit signed integer frequently overflows, resulting in
a bad value for Random.nextInt().

See previous pull request @ https://github.com/nathanmarz/storm/pull/713

Here's the exception:

```
2013-10-30 16:30:04 b.s.m.n.Client [INFO] Reconnect ... [26]
2013-10-30 16:30:04 b.s.m.n.Client [INFO] Reconnect ... [29]
2013-10-30 16:30:04 b.s.m.n.Client [INFO] Reconnect ... [27]
2013-10-30 16:30:04 b.s.m.n.Client [INFO] Reconnect ... [30]
2013-10-30 16:30:04 STDIO [ERROR] Oct 30, 2013 4:30:04 PM org.jboss.netty.channel.DefaultChannelPipeline
WARNING: An exception was thrown by a user handler while handling an exception event ([id: 0x27388d8c] EXCEPTION: java.net.ConnectException: Connection refused: i-0e040e75/10.58.82.253:31002)
java.lang.IllegalArgumentException: n must be positive
    at java.util.Random.nextInt(Random.java:300)
    at backtype.storm.messaging.netty.Client.getSleepTimeMs(Client.java:97)
    at backtype.storm.messaging.netty.Client.reconnect(Client.java:78)
    at backtype.storm.messaging.netty.StormClientHandler.exceptionCaught(StormClientHandler.java:108)
    at org.jboss.netty.handler.codec.frame.FrameDecoder.exceptionCaught(FrameDecoder.java:377)
    at org.jboss.netty.channel.Channels.fireExceptionCaught(Channels.java:525)
    at org.jboss.netty.channel.socket.nio.NioClientBoss.processSelectedKeys(NioClientBoss.java:110)
    at org.jboss.netty.channel.socket.nio.NioClientBoss.process(NioClientBoss.java:79)
    at org.jboss.netty.channel.socket.nio.AbstractNioSelector.run(AbstractNioSelector.java:312)
    at org.jboss.netty.channel.socket.nio.NioClientBoss.run(NioClientBoss.java:42)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
    at java.lang.Thread.run(Thread.java:744)
2013-10-30 16:30:05 b.s.m.n.Client [INFO] Reconnect ... [29]
2013-10-30 16:30:06 b.s.m.n.Client [INFO] Reconnect ... [28]
```
