### PR TITLE
update zookeeper from version 3.3.3 to 3.4.5; fix lein compile testing.c...

### DIFF
--- a/storm-core/project.clj
+++ b/storm-core/project.clj
@@ -9,7 +9,9 @@
                   :exclusions [org.slf4j/slf4j-api]]
                  [clj-time "0.4.1"]
                  [com.netflix.curator/curator-framework "1.0.1"
-                  :exclusions [log4j/log4j]]
+                  :exclusions [log4j/log4j org.apache.zookeeper/zookeeper]]
+                 [org.apache.zookeeper/zookeeper "3.4.5"
+                  :exclusions [com.sun.jmx/jmxri com.sun.jdmk/jmxtools javax.jms/jms log4j/log4j jline org.slf4j/slf4j-log4j12]]
                  [backtype/jzmq "2.1.0"]
                  [com.googlecode.json-simple/json-simple "1.1"]
                  [compojure "1.1.3"]
@@ -34,6 +36,7 @@
   :test-paths ["test/clj"]
   :resource-paths ["../conf"]
   :target-path "target"
+  :jar-exclusions [#".svn" #".DS_Store"]
 
   :profiles {:dev {:resource-paths ["src/dev"]
                    :dependencies [[org.mockito/mockito-all "1.9.5"]]}

--- a/storm-core/src/clj/backtype/storm/testing4j.clj
+++ b/storm-core/src/clj/backtype/storm/testing4j.clj
@@ -1,4 +1,5 @@
 (ns backtype.storm.testing4j
+  (:require [backtype.storm.LocalCluster :as LocalCluster])
   (:import [java.util Map List Collection ArrayList])
   (:import [backtype.storm Config ILocalCluster LocalCluster])
   (:import [backtype.storm.generated StormTopology])

--- a/storm-core/src/clj/backtype/storm/zookeeper.clj
+++ b/storm-core/src/clj/backtype/storm/zookeeper.clj
@@ -6,7 +6,7 @@
             ZooDefs ZooDefs$Ids CreateMode WatchedEvent Watcher$Event Watcher$Event$KeeperState
             Watcher$Event$EventType KeeperException$NodeExistsException])
   (:import [org.apache.zookeeper.data Stat])
-  (:import [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxn$Factory])
+  (:import [org.apache.zookeeper.server ZooKeeperServer NIOServerCnxnFactory])
   (:import [java.net InetSocketAddress BindException])
   (:import [java.io File])
   (:import [backtype.storm.utils Utils ZookeeperAuthInfo])
@@ -141,7 +141,7 @@
   (let [localfile (File. localdir)
         zk (ZooKeeperServer. localfile localfile 2000)
         [retport factory] (loop [retport (if port port 2000)]
-                            (if-let [factory-tmp (try-cause (NIOServerCnxn$Factory. (InetSocketAddress. retport))
+                            (if-let [factory-tmp (try-cause (doto (NIOServerCnxnFactory.) (.configure (InetSocketAddress. retport) 0))
                                               (catch BindException e
                                                 (when (> (inc retport) (if port port 65535))
                                                   (throw (RuntimeException. "No port is available to launch an inprocess zookeeper.")))))]

--- a/storm-core/src/jvm/backtype/storm/StormSubmitter.java
+++ b/storm-core/src/jvm/backtype/storm/StormSubmitter.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.thrift7.TException;
 import org.json.simple.JSONValue;
 
@@ -59,6 +60,12 @@ public class StormSubmitter {
         }
         stormConf = new HashMap(stormConf);
         stormConf.putAll(Utils.readCommandLineOpts());
+	for (Object confName : stormConf.keySet()) {
+		String confValue = String.valueOf(stormConf.get(confName));
+		if (NumberUtils.isNumber(confValue)) {
+			stormConf.put(confName, NumberUtils.createNumber(confValue));
+		}
+	}
         Map conf = Utils.readStormConfig();
         conf.putAll(stormConf);
         try {


### PR DESCRIPTION
1: update  zookeeper from version 3.3.3 to 3.4.5 

2: fix lein compile error 
22117 [main] ERROR org.apache.zookeeper.server.NIOServerCnxnFactory - Thread Thread[main,5,main] died
clojure.lang.Compiler$CompilerException: java.lang.ClassNotFoundException: backtype.storm.LocalCluster, compiling:(testing4j.clj:1)
    at clojure.lang.Compiler$InvokeExpr.eval(Compiler.java:3387) ~[clojure-1.4.0.jar:na]
    at clojure.lang.Compiler.compile1(Compiler.java:7035) ~[clojure-1.4.0.jar:na]
    at clojure.lang.Compiler.compile1(Compiler.java:7025) ~[clojure-1.4.0.jar:na]
    at clojure.lang.Compiler.compile(Compiler.java:7097) ~[clojure-1.4.0.jar:na]
    at clojure.lang.RT.compile(RT.java:387) ~[clojure-1.4.0.jar:na]

3: fix lein jar error 
Compiling storm.trident.testing
java.util.zip.ZipException: duplicate entry: backtype/.svn/all-wcprops
    at java.util.zip.ZipOutputStream.putNextEntry(ZipOutputStream.java:175)
    at java.util.jar.JarOutputStream.putNextEntry(JarOutputStream.java:92)
    at sun.reflect.GeneratedMethodAccessor58.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at clojure.lang.Reflector.invokeMatchingMethod(Reflector.java:93)
    at clojure.lang.Reflector.invokeInstanceMethod(Reflector.java:28)
    at leiningen.jar$fn__7204.invoke(jar.clj:76)
X
