### PR TITLE
Fix netty transport unit tests

### DIFF
--- a/storm-netty/test/clj/backtype/storm/messaging/netty_integration_test.clj
+++ b/storm-netty/test/clj/backtype/storm/messaging/netty_integration_test.clj
@@ -13,7 +13,10 @@
                                                     STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
                                                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
                                                     STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000 
-                                                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000}]
+                                                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                                                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                                                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                                                    }]
     (let [topology (thrift/mk-topology
                      {"1" (thrift/mk-spout-spec (TestWordSpout. true) :parallelism-hint 4)}
                      {"2" (thrift/mk-bolt-spec {"1" :shuffle} (TestGlobalCount.)

--- a/storm-netty/test/clj/backtype/storm/messaging/netty_unit_test.clj
+++ b/storm-netty/test/clj/backtype/storm/messaging/netty_unit_test.clj
@@ -14,7 +14,10 @@
                     STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
                     STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000 
-                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000 }
+                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                    }
         context (TransportFactory/makeContext storm-conf)
         server (.bind context nil port)
         client (.connect context nil "localhost" port)
@@ -32,7 +35,10 @@
                     STORM-MESSAGING-NETTY-BUFFER-SIZE 102400
                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
                     STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000 
-                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000 }
+                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                    }
         context (TransportFactory/makeContext storm-conf)
         server (.bind context nil port)
         client (.connect context nil "localhost" port)
@@ -50,7 +56,10 @@
                     STORM-MESSAGING-NETTY-BUFFER-SIZE 1024
                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
                     STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000 
-                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000 }
+                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                    }
         context (TransportFactory/makeContext storm-conf)
         client (.connect context nil "localhost" port)
         _ (.send client task (.getBytes req_msg))
@@ -68,7 +77,10 @@
                     STORM-MESSAGING-NETTY-BUFFER-SIZE 1024000
                     STORM-MESSAGING-NETTY-MAX-RETRIES 10
                     STORM-MESSAGING-NETTY-MIN-SLEEP-MS 1000 
-                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000}
+                    STORM-MESSAGING-NETTY-MAX-SLEEP-MS 5000
+                    STORM-MESSAGING-NETTY-SERVER-WORKER-THREADS 1
+                    STORM-MESSAGING-NETTY-CLIENT-WORKER-THREADS 1
+                    }
         context (TransportFactory/makeContext storm-conf)
         server (.bind context nil port)
         client (.connect context nil "localhost" port)]


### PR DESCRIPTION
Unit tests were failing because they did not define values for the number of client/server worker threads.
