### PR TITLE
Add .tar.gz generation to build_release.sh and fix download URL in 'storm' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ NANNY
 .lein-failures
 _release
 *.zip
+*.tar.gz
 .lein-deps-sum
 *.iml
 target

--- a/bin/build_release.sh
+++ b/bin/build_release.sh
@@ -13,7 +13,8 @@ echo Making release $RELEASE
 DIR=`pwd`/_release/storm-$RELEASE
 
 rm -rf _release
-rm -f *.zip 
+rm -f *.zip
+rm -f *.tar.gz
 $LEIN pom || exit 1
 mkdir -p $DIR/lib
 
@@ -56,7 +57,10 @@ cp LICENSE.html $DIR/
 
 cd _release
 zip -r storm-$RELEASE.zip *
+mv storm-*.zip ../
+tar -cvzf ../storm-$RELEASE.tar.gz ./
+
 cd ..
-mv _release/storm-*.zip .
+
 rm -rf _release
 

--- a/bin/storm
+++ b/bin/storm
@@ -39,7 +39,7 @@ def get_config_opts():
 if not os.path.exists(STORM_DIR + "/RELEASE"):
     print "******************************************"
     print "The storm client can only be run from within a release. You appear to be trying to run the client from a checkout of Storm's source code."
-    print "\nYou can download a Storm release at https://github.com/nathanmarz/storm/downloads"
+    print "\nYou can download a Storm release at http://storm-project.net/downloads.html"
     print "******************************************"
     sys.exit(1)  
 


### PR DESCRIPTION
A few minor changes:
- Also generate a .tar.gz archive for release.
- Fix the download URL in the 'storm' command
- add *.tar.gz to .gitignore
