### PR TITLE
Added logging level to multilang protocol spout and bolt.

### DIFF
--- a/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
+++ b/storm-core/src/jvm/backtype/storm/spout/ShellSpout.java
@@ -24,6 +24,7 @@ import backtype.storm.utils.Utils;
 import java.util.Map;
 import java.util.List;
 import java.io.IOException;
+import java.lang.reflect.Method;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.json.simple.JSONObject;
@@ -104,7 +105,17 @@ public class ShellSpout implements ISpout {
                     return;
                 } else if (command.equals("log")) {
                     String msg = (String) action.get("msg");
-                    LOG.info("Shell msg: " + msg);
+                    String level = "info";
+                    if (action.has("level")) {
+                        level = (String) action.get("level");
+                    }
+                    try {
+                        Method logWithLevel = LOG.getClass().getMethod(level, String.class);
+                        logWithLevel.invoke(LOG, "Shell msg: " + msg);
+                    } catch (java.lang.NoSuchMethodException e) {
+                        LOG.warn("Unknown log level {} called for. Logging as 'info'.", level);
+                        LOG.info("Shell msg: " + msg);
+                    }
                 } else if (command.equals("emit")) {
                     String stream = (String) action.get("stream");
                     if (stream == null) stream = Utils.DEFAULT_STREAM_ID;

--- a/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
+++ b/storm-core/src/jvm/backtype/storm/task/ShellBolt.java
@@ -32,6 +32,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.lang.reflect.Method;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.json.simple.JSONObject;
@@ -124,7 +125,17 @@ public class ShellBolt implements IBolt {
                             handleError(action);
                         } else if (command.equals("log")) {
                             String msg = (String) action.get("msg");
-                            LOG.info("Shell msg: " + msg);
+                            String level = "info";
+                            if (action.has("level")) {
+                                level = (String) action.get("level");
+                            }
+                            try {
+                                Method logWithLevel = LOG.getClass().getMethod(level, String.class);
+                                logWithLevel.invoke(LOG, "Shell msg: " + msg);
+                            } catch (java.lang.NoSuchMethodException e) {
+                                LOG.warn("Unknown log level {} called for. Logging as 'info'.", level);
+                                LOG.info("Shell msg: " + msg);
+                            }
                         } else if (command.equals("emit")) {
                             handleEmit(action);
                         }

--- a/storm-core/src/multilang/py/storm.py
+++ b/storm-core/src/multilang/py/storm.py
@@ -133,8 +133,8 @@ def fail(tup):
 def reportError(msg):
     sendMsgToParent({"command": "error", "msg": msg})
 
-def log(msg):
-    sendMsgToParent({"command": "log", "msg": msg})
+def log(msg, level="info"):
+    sendMsgToParent({"command": "log", "msg": msg, "level": level})
 
 def initComponent():
     setupInfo = readMsg()


### PR DESCRIPTION
I would like to be able to log at varying levels from multilang spouts and bolts. I updated the log function in storm.py to make the call.

I propose the following change in the wiki doc https://github.com/nathanmarz/storm/wiki/Multilang-protocol as well.

{
    "command": "log",
    // the message to log
    "msg": "hello world!",
    // the level to log at (optional, defaults to info)
    "level": "warn"
}
