### PR TITLE
Fix JVM_OPTS to be a list, not string

### DIFF
--- a/bin/storm
+++ b/bin/storm
@@ -155,7 +155,7 @@ def jar(jarfile, klass, *args):
         jvmtype="-client",
         extrajars=[jarfile, USER_CONF_DIR, STORM_DIR + "/bin"],
         args=args,
-        jvmopts=[' '.join(filter(None, [JAR_JVM_OPTS, "-Dstorm.jar=" + jarfile]))])
+        jvmopts=filter(None, [JAR_JVM_OPTS, "-Dstorm.jar=" + jarfile]))
 
 def kill(*args):
     """Syntax: [storm kill topology-name [-w wait-time-secs]]


### PR DESCRIPTION
The jvm options are being passed to java in the os.exec call as a single string, space-delimited, instead of as individual args in the args array.

For example, if you set STORM_JAR_JVM_OPTS to something like '-Djava.io.tmpdir=/mnt/tmp', then ./bin/storm will append '-Dstorm.jar=/home/ubuntu/example.jar' to the list and join it into a single string.
Some versions of java will parse it as a single option: 'java.io.tmpdir' = '/mnt/tmp -Dstorm.jar=/home/ubuntu/example.jar'.

This causes the storm jar command to fail with the error "Must submit topologies using the 'storm' client script so that StormSubmitter knows which jar to upload." because the storm.jar system property is missing.
