### PR TITLE
Update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2014 Nathan Marz
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hello. I noticed the placeholder for the copyright year and name weren't filled in. Copyright notices must reflect the current year, so this commit updates the listed year to 2014 and adds the copyright holder's name.

See http://www.copyright.gov/circs/circ01.pdf for more info.
